### PR TITLE
Wbeep 89 dynamic sizing of map on load

### DIFF
--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -129,7 +129,7 @@
   @import"~mapbox-gl/dist/mapbox-gl.css";
 
   #map {
-    height: 900px;
+    height: 60vh;
   }
 
   /* override USWDS style to prevent title from wrapping too soon */


### PR DESCRIPTION
Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Dynamic Sizing of Map div
-----------
Change height of #map div to accommodate different viewports.

Description
-----------
The original configuration of the #map div used a fixed height of 900px.  This caused the map
canvas to extend beyond the viewport on most clients, requiring the user to scroll to see the full map.  This change styles the #map div with a relative size of 60vh, which renders the map responsively regardless of the client or viewport size.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial