### PR TITLE
changes to mapbox style to use new tiles

### DIFF
--- a/src/assets/mapStyles/mapStyles.js
+++ b/src/assets/mapStyles/mapStyles.js
@@ -82,14 +82,12 @@ export default {
                 },
                 'paint': {
                     'fill-color': {
-                        'property': 'SoilMoisture',
+                        'property': 'value',
                         'type': 'categorical',
                         'stops': [
-                            ['very high','#144873'],
                             ['high','#A7B9D7'],
-                            ['average','#FED98E'],
+                            ['medium','#FED98E'],
                             ['low', '#EDAA5F'],
-                            ['very low','#CC4C02'],
                             ["",'#000000'],
                         ]
                     },
@@ -112,15 +110,13 @@ export default {
                 },
                 'paint': {
                     'line-color': {
-                        'property': 'SoilMoisture',
+                        'property': 'value',
                         'type': 'categorical',
                         'stops': [
+                            ['high','#A7B9D7'],
+                            ['medium','#FED98E'],
+                            ['low', '#EDAA5F'],
                             ["",'#000000'],
-                            ['very low','#823102'],
-                            ['low', '#C28C4E'],
-                            ['average','#D0B275'],
-                            ['high','#8998B0'],
-                            ['very high','#113B5F'],
                         ]
                     },
                     'line-width': 1


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Changes to MapBox Styles to Use New Tiles
-----------
Attempting to sync the Vue App with the new tiles.  Currently the map  on http://wbeep-test-website.s3-website-us-west-2.amazonaws.com/ appears black. This (hopefully) is because the Mapbox styles do not match what is in the tiles.

This pull request serves two purposes:
1) Match the needed 'property' and 'stops' found in the new tiles
2) Test the auto deploy and build of the Vue application

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial