### PR TITLE
added jenkins exclude for openmaptiles

### DIFF
--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -63,7 +63,7 @@ pipeline {
                     }
                 }
                 sh """
-                    aws s3 rm "${targetDomain}" --recursive --exclude "mbtiles/*" --exclude "tiles/*" --exclude "basetiles/*"
+                    aws s3 rm "${targetDomain}" --recursive --exclude "mbtiles/*" --exclude "tiles/*" --exclude "basetiles/*" --exclude "openmaptiles/*"
                     aws s3 cp "$WORKSPACE/dist" "${targetDomain}" --recursive
                 """
             }


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Add Jenkins Exclude for 'openmaptiles' folder on s3
-----------
Need to put our new tiles on S3 for hosting and don't want the Jenkins job to delete them on every build, so I added an exclude statement to the Jenkins file.