### PR TITLE
Add event tracking for google analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Added Google Analytics event tracking for most user click actions
 - Fixed changelog typos
 
 ## [0.0.2] - 2019-10-18

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -17,7 +17,10 @@
 
     <p>
       Estimates of natural water storage are calculated using the National Hydrologic Model (NHM) Infrastructure (Regan et al. 2019)
-      configured with the <a href="https://www.usgs.gov/software/precipitation-runoff-modeling-system-prms" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for precipitation-runoff-modeling-system-prms')">Precipitation Runoff Modeling
+      configured with the <a
+        href="https://www.usgs.gov/software/precipitation-runoff-modeling-system-prms"
+        @click="runGoogleAnalytics('about page', 'click', 'clicked text link for precipitation-runoff-modeling-system-prms')"
+      >Precipitation Runoff Modeling
         System</a> (PRMS; Markstrom et al., 2015). The PRMS is a modular, deterministic, distributed-parameter, physical process-based
       hydrologic simulation code that can be used to evaluate the effects of various combinations of climate and landscape on
       hydrologic response at the watershed scale  (Regan et al., 2018).The PRMS application of the NHM (NHM-PRMS) is used here to
@@ -48,7 +51,10 @@
     <h3>About IWAAs</h3>
 
     <p>
-      The <a href="https://www.usgs.gov/mission-areas/water-resources/science/integrated-water-availability-assessments-iwaas" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for IWAAs')">USGS Integrated Water Availability Assessments (IWAAs)</a>
+      The <a
+        href="https://www.usgs.gov/mission-areas/water-resources/science/integrated-water-availability-assessments-iwaas"
+        @click="runGoogleAnalytics('about page', 'click', 'clicked text link for IWAAs')"
+      >USGS Integrated Water Availability Assessments (IWAAs)</a>
       are a multi-extent, stakeholder driven, near real-time census and seasonal
       prediction of water availability for both human and ecological uses at
       regional and national extents.
@@ -56,15 +62,36 @@
 
     <p>
       The USGS IWAAs combine resources and knowledge gained from previous and
-      ongoing USGS efforts such as <a href="https://water.usgs.gov/watercensus/focusarea.html" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Focus Area Studies')">Focus Area Studies</a>,
-      <a href="https://water.usgs.gov/watercensus/groundwater.html" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Regional Groundwater Availability Studies')">Regional Groundwater Availability Studies</a>,
-      <a href="https://water.usgs.gov/watercensus/water-use.html" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Water Use Estimation')">Water Use estimation</a>,
-      <a href="https://water.usgs.gov/watercensus/ecowater.html" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Ecological Water Needs')">Ecological Water Needs</a>,
-      and <a href="https://water.usgs.gov/watercensus/streamflow.html" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Streamflow estimation')">Streamflow estimation</a>,
+      ongoing USGS efforts such as <a
+        href="https://water.usgs.gov/watercensus/focusarea.html"
+        @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Focus Area Studies')"
+      >Focus Area Studies</a>,
+      <a
+        href="https://water.usgs.gov/watercensus/groundwater.html"
+        @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Regional Groundwater Availability Studies')"
+      >Regional Groundwater Availability Studies</a>,
+      <a
+        href="https://water.usgs.gov/watercensus/water-use.html"
+        @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Water Use Estimation')"
+      >Water Use estimation</a>,
+      <a
+        href="https://water.usgs.gov/watercensus/ecowater.html"
+        @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Ecological Water Needs')"
+      >Ecological Water Needs</a>,
+      and <a
+        href="https://water.usgs.gov/watercensus/streamflow.html"
+        @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Streamflow estimation')"
+      >Streamflow estimation</a>,
       in addition to utilizing and providing feedback to the
-      <a href="http://water.noaa.gov/about/nwm" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for National Water Model')">National Water Model</a>. The IWAAs
+      <a
+        href="http://water.noaa.gov/about/nwm"
+        @click="runGoogleAnalytics('about page', 'click', 'clicked text link for National Water Model')"
+      >National Water Model</a>. The IWAAs
       are designed to provide information to meet the goals of the
-      <a href="https://water.usgs.gov/watercensus/index.html" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for National Water Census')">National Water Census</a> as established through the SECURE Water Act.
+      <a
+        href="https://water.usgs.gov/watercensus/index.html"
+        @click="runGoogleAnalytics('about page', 'click', 'clicked text link for National Water Census')"
+      >National Water Census</a> as established through the SECURE Water Act.
     </p>
 
     <p>

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -17,7 +17,7 @@
 
     <p>
       Estimates of natural water storage are calculated using the National Hydrologic Model (NHM) Infrastructure (Regan et al. 2019)
-      configured with the <a href="https://www.usgs.gov/software/precipitation-runoff-modeling-system-prms">Precipitation Runoff Modeling
+      configured with the <a href="https://www.usgs.gov/software/precipitation-runoff-modeling-system-prms" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for precipitation-runoff-modeling-system-prms')">Precipitation Runoff Modeling
         System</a> (PRMS; Markstrom et al., 2015). The PRMS is a modular, deterministic, distributed-parameter, physical process-based
       hydrologic simulation code that can be used to evaluate the effects of various combinations of climate and landscape on
       hydrologic response at the watershed scale  (Regan et al., 2018).The PRMS application of the NHM (NHM-PRMS) is used here to
@@ -48,7 +48,7 @@
     <h3>About IWAAs</h3>
 
     <p>
-      The <a href="https://www.usgs.gov/mission-areas/water-resources/science/integrated-water-availability-assessments-iwaas">USGS Integrated Water Availability Assessments (IWAAs)</a>
+      The <a href="https://www.usgs.gov/mission-areas/water-resources/science/integrated-water-availability-assessments-iwaas" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for IWAAs')">USGS Integrated Water Availability Assessments (IWAAs)</a>
       are a multi-extent, stakeholder driven, near real-time census and seasonal
       prediction of water availability for both human and ecological uses at
       regional and national extents.
@@ -56,20 +56,20 @@
 
     <p>
       The USGS IWAAs combine resources and knowledge gained from previous and
-      ongoing USGS efforts such as <a href="https://water.usgs.gov/watercensus/focusarea.html">Focus Area Studies</a>,
-      <a href="https://water.usgs.gov/watercensus/groundwater.html">Regional Groundwater Availability Studies</a>,
-      <a href="https://water.usgs.gov/watercensus/water-use.html">Water Use estimation</a>,
-      <a href="https://water.usgs.gov/watercensus/ecowater.html">Ecological Water Needs</a>,
-      and <a href="https://water.usgs.gov/watercensus/streamflow.html">Streamflow estimation</a>,
+      ongoing USGS efforts such as <a href="https://water.usgs.gov/watercensus/focusarea.html" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Focus Area Studies')">Focus Area Studies</a>,
+      <a href="https://water.usgs.gov/watercensus/groundwater.html" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Regional Groundwater Availability Studies')">Regional Groundwater Availability Studies</a>,
+      <a href="https://water.usgs.gov/watercensus/water-use.html" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Water Use Estimation')">Water Use estimation</a>,
+      <a href="https://water.usgs.gov/watercensus/ecowater.html" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Ecological Water Needs')">Ecological Water Needs</a>,
+      and <a href="https://water.usgs.gov/watercensus/streamflow.html" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for Streamflow estimation')">Streamflow estimation</a>,
       in addition to utilizing and providing feedback to the
-      <a href="http://water.noaa.gov/about/nwm">National Water Model</a>. The IWAAs
+      <a href="http://water.noaa.gov/about/nwm" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for National Water Model')">National Water Model</a>. The IWAAs
       are designed to provide information to meet the goals of the
-      <a href="https://water.usgs.gov/watercensus/index.html">National Water Census</a> as established through the SECURE Water Act.
+      <a href="https://water.usgs.gov/watercensus/index.html" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for National Water Census')">National Water Census</a> as established through the SECURE Water Act.
     </p>
 
     <p>
       <router-link to="/">
-        <button>
+        <button @click="runGoogleAnalytics('about page', 'click', 'user clicked returned to map button')">
           Return to map
         </button>
       </router-link>
@@ -94,6 +94,11 @@
             return {
                 pageTitle: 'About'
             };
+        },
+        methods: {
+            runGoogleAnalytics(eventName, action, label) {
+                this.$ga.event(eventName, action, label)
+            }
         }
     }
 </script>

--- a/src/components/FooterUSGS.vue
+++ b/src/components/FooterUSGS.vue
@@ -63,6 +63,7 @@
               <a
                 href="https://twitter.com/usgs"
                 target="_blank"
+                @click="runGoogleAnalytics('twitter', 'click', 'user selected twitter social link')"
               >
                 <font-awesome-icon :icon="{ prefix: 'fab', iconName: 'twitter-square' }"><span class="only">Twitter</span></font-awesome-icon>
               </a>
@@ -71,6 +72,7 @@
               <a
                 href="https://facebook.com/usgeologicalsurvey"
                 target="_blank"
+                @click="runGoogleAnalytics('facebook', 'click', 'user selected facebook social link')"
               >
                 <font-awesome-icon :icon="{ prefix: 'fab', iconName: 'facebook-square' }"><span class="only">Facebook</span></font-awesome-icon>
               </a>
@@ -79,6 +81,7 @@
               <a
                 href="https://github.com/usgs"
                 target="_blank"
+                @click="runGoogleAnalytics('github', 'click', 'user selected github social link')"
               >
                 <font-awesome-icon :icon="{ prefix: 'fab', iconName: 'github' }"><span class="only">GitHub</span></font-awesome-icon>
               </a>
@@ -87,6 +90,7 @@
               <a
                 href="https://flickr.com/usgeologicalsurvey"
                 target="_blank"
+                @click="runGoogleAnalytics('flickr', 'click', 'user selected flickr social link')"
               >
                 <font-awesome-icon :icon="{ prefix: 'fab', iconName: 'flickr' }"><span class="only">Flickr</span></font-awesome-icon>
               </a>
@@ -95,6 +99,7 @@
               <a
                 href="http://youtube.com/usgs"
                 target="_blank"
+                @click="runGoogleAnalytics('youtube', 'click', 'user selected youtube social link')"
               >
                 <font-awesome-icon :icon="{ prefix: 'fab', iconName: 'youtube-square' }"><span class="only">YouTube</span></font-awesome-icon>
               </a>
@@ -103,6 +108,7 @@
               <a
                 href="https://instagram.com/usgs"
                 target="_blank"
+                @click="runGoogleAnalytics('instagram', 'click', 'user selected instagram social link')"
               >
                 <font-awesome-icon :icon="{ prefix: 'fab', iconName: 'instagram' }"><span class="only">Instagram</span></font-awesome-icon>
               </a>
@@ -118,7 +124,12 @@
 
 <script>
     export default {
-        name: 'FooterUSGS'
+        name: 'FooterUSGS',
+        methods: {
+            runGoogleAnalytics(eventName, action, label) {
+                this.$ga.event(eventName, action, label)
+            }
+        }
     }
 </script>
 

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -107,7 +107,14 @@ export default {
     };
   },
   methods: {
+    runGoogleAnalytics(eventName, action, label) {
+        this.$ga.event(eventName, action, label)
+    },
     onMapLoaded(event) {
+      // We need to get the global Google Analytics (GA) plugin object 'this.$ga' into this scope, so let's make
+      // a local variable and assign our GA event tracking method to that.
+      let googleAnalytics = this.runGoogleAnalytics;        
+
       let map = event.map; // This gives us access to the map as an object but only after the map has loaded
 
       // Once map is loaded, zoom in a bit more so that the map neatly fills the screen
@@ -218,7 +225,8 @@ export default {
           link.textContent = id;
           // Creates a click event for each button so that when clicked by the user, the visibility property
           // is changed as is the class (color) of the button
-          link.onclick = function(e) {
+            link.onclick = function(e) {
+              googleAnalytics('layers-menu', 'click', 'user clicked ' + id);
             let clickedLayer = this.textContent;
             e.preventDefault();
             e.stopPropagation();

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -113,7 +113,7 @@ export default {
     onMapLoaded(event) {
       // We need to get the global Google Analytics (GA) plugin object 'this.$ga' into this scope, so let's make
       // a local variable and assign our GA event tracking method to that.
-      let googleAnalytics = this.runGoogleAnalytics;        
+      let googleAnalytics = this.runGoogleAnalytics;
 
       let map = event.map; // This gives us access to the map as an object but only after the map has loaded
 

--- a/src/components/MapLayers.vue
+++ b/src/components/MapLayers.vue
@@ -1,5 +1,5 @@
 <template>
-  <div />
+  <div><a href="#" @click="runtest">test</a></div>
 </template>
 <script>
 import { icon } from "@fortawesome/fontawesome-svg-core";
@@ -9,16 +9,29 @@ export default {
   inject: ["mapbox", "map", "actions"],
   data() {
     return {
-      control: null
+      control: null,
+      googleAnalyticsTracker: this.$ga
     };
+  },
+  created: function() {
+      this.recordForGoogleAnalytics();
   },
   mounted() {
     this.createCustomControl();
   },
   methods: {
+    recordForGoogleAnalytics: function(nameOfTrackedElement, actionTypeRecorded, moreDetailedActionType, clickCount)  {
+        return this.$ga.event(nameOfTrackedElement, actionTypeRecorded, moreDetailedActionType, clickCount);
+    },
+    runtest() {console.log('test dun run')},
+    getTracker() {
+        return this.$ga
+    },
+
     createCustomControl() {
       class customControl {
         onAdd(map) {
+            console.log('maybe ', this.googleAnalyticsTracker)
           let control = this.control;
           this.map = map;
           this.control = document.createElement("div");
@@ -56,7 +69,7 @@ export default {
   }
 };
 </script>
-<style lang="scss">
+<style scoped lang="scss">
 .mapboxgl-ctrl .maplayersIcon svg {
   width: 18px;
   height: 18px;

--- a/src/components/MapLayers.vue
+++ b/src/components/MapLayers.vue
@@ -1,5 +1,5 @@
 <template>
-  <div><a href="#" @click="runtest">test</a></div>
+  <div/>
 </template>
 <script>
 import { icon } from "@fortawesome/fontawesome-svg-core";
@@ -9,29 +9,19 @@ export default {
   inject: ["mapbox", "map", "actions"],
   data() {
     return {
-      control: null,
-      googleAnalyticsTracker: this.$ga
+      control: null
     };
-  },
-  created: function() {
-      this.recordForGoogleAnalytics();
   },
   mounted() {
     this.createCustomControl();
   },
   methods: {
-    recordForGoogleAnalytics: function(nameOfTrackedElement, actionTypeRecorded, moreDetailedActionType, clickCount)  {
-        return this.$ga.event(nameOfTrackedElement, actionTypeRecorded, moreDetailedActionType, clickCount);
-    },
-    runtest() {console.log('test dun run')},
-    getTracker() {
-        return this.$ga
-    },
+
+
 
     createCustomControl() {
       class customControl {
         onAdd(map) {
-            console.log('maybe ', this.googleAnalyticsTracker)
           let control = this.control;
           this.map = map;
           this.control = document.createElement("div");

--- a/src/components/MapLayers.vue
+++ b/src/components/MapLayers.vue
@@ -1,5 +1,5 @@
 <template>
-  <div/>
+  <div />
 </template>
 <script>
 import { icon } from "@fortawesome/fontawesome-svg-core";
@@ -13,16 +13,16 @@ export default {
     };
   },
   mounted() {
-    this.createCustomControl();
+    this.createCustomControl(this.runGoogleAnalytics);
   },
   methods: {
-
-
-
-    createCustomControl() {
+    runGoogleAnalytics(eventName, action, label) {
+        console.log('ran the ga')
+      this.$ga.event(eventName, action, label)
+    },
+    createCustomControl(googleAnalytics) {
       class customControl {
         onAdd(map) {
-          let control = this.control;
           this.map = map;
           this.control = document.createElement("div");
           this.control.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
@@ -30,6 +30,7 @@ export default {
           this.button.id = "layersIcon";
           this.button.className = "mapboxgl-ctrl-icon maplayersIcon";
           this.button.onclick = function(e) {
+              googleAnalytics('layers-icon', 'click', 'user opened layers menu');
             e.preventDefault();
             e.stopPropagation();
             let toggleDiv = document.getElementById("mapLayersToggleContainer");

--- a/src/components/MapLegend.vue
+++ b/src/components/MapLegend.vue
@@ -10,12 +10,14 @@
           <a
             id="legendInfoButton"
             class="legendIcon"
+            @click="runGoogleAnalytics('legend', 'click', 'user clicked info icon')"
           >
             <font-awesome-icon icon="info" />
           </a>
           <a
             id="legendMinus"
             class="legendIcon"
+            @click="runGoogleAnalytics('legend', 'click', 'user reduced legend')"
           >
             <font-awesome-icon icon="minus" />
           </a>
@@ -95,6 +97,7 @@
         <a
           id="legendPlus"
           class="legendIcon"
+          @click="runGoogleAnalytics('legend', 'click', 'user expanded legend')"
         >
           <font-awesome-icon icon="plus" />
         </a>
@@ -129,6 +132,9 @@ export default {
     this.createLegend();
   },
   methods: {
+      runGoogleAnalytics(eventName, action, label) {
+          this.$ga.event(eventName, action, label)
+      },
     createLegend() {
       // get the style layers from the map styles object
       let styleLayers = mapStyles.style.layers;

--- a/src/components/MapSubtitle.vue
+++ b/src/components/MapSubtitle.vue
@@ -29,7 +29,9 @@
               Map shading indicates the current natural water storage relative to historical conditions for this time of year.
             </p>
             <router-link to="/about">
-              <button @click="runGoogleAnalytics('subtitle', 'click', 'user went to about page')">Learn More</button>
+              <button @click="runGoogleAnalytics('subtitle', 'click', 'user went to about page')">
+                Learn More
+              </button>
             </router-link>
           </div>
         </div>

--- a/src/components/MapSubtitle.vue
+++ b/src/components/MapSubtitle.vue
@@ -9,6 +9,7 @@
           id="subtitleIcon"
           href="javascript:void(0);"
           class="icon"
+          @click="runGoogleAnalytics('subtitle', 'click', 'user opened about text box')"
         >
           <font-awesome-icon icon="info" />
         </a>
@@ -28,7 +29,7 @@
               Map shading indicates the current natural water storage relative to historical conditions for this time of year.
             </p>
             <router-link to="/about">
-              <button>Learn More</button>
+              <button @click="runGoogleAnalytics('subtitle', 'click', 'user went to about page')">Learn More</button>
             </router-link>
           </div>
         </div>
@@ -40,7 +41,12 @@
 
 <script>
   export default {
-    name: "MapSubtitle"
+    name: "MapSubtitle",
+    methods: {
+        runGoogleAnalytics(eventName, action, label) {
+            this.$ga.event(eventName, action, label)
+        }
+    }
   };
 </script>
 


### PR DESCRIPTION
Before making a pull request
----------------------------
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'
- [x] Make sure all tests run
- [x] Update the changelog appropriately

Add Google Analytics Event Tracking
-----------
Added Google Analytics Event Tracking for most user click events.

Description
-----------
Adding Google Analytics (GA) Event Tracking was an easy task for most items that users can interact with using a click. This was accomplished using a '@click' Vue binding and feeding in the desired GA parameters. The challenge came with getting GA to attach to links that were dynamically created such as those in the 'layers menu' and the legend. That required some sort of passing of the GA global variable (this.$ga) into the scope of the function created the clickable items. I did get this to work, but I am not sure that what I came up with is the best possible method. 

Also, I could not find an obvious way of adding GA tracking to the standard Mapbox components like the 'fullscreen' button. If we find this is something needed, we can look into it more later.  

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial