### PR TITLE
Roads toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Road toggle and road layers combined
 - Flow Detail can only have one active button functionality
 - Added aria labels to links with no text content
 - Added Flow Detail to layers toggle and renamed stream titles

--- a/src/assets/mapStyles/mapStyles.js
+++ b/src/assets/mapStyles/mapStyles.js
@@ -94,12 +94,13 @@ export default {
             },
             {
                 'filter': ['all', ['==', '$type', 'LineString'],
-                    ['in', 'class', 'minor', 'service']
+                    ['in', 'class', 'minor', 'service', 'trunk', 'primary', 'secondary', 'tertiary', 'motorway']
                 ],
-                'id': 'road_minor',
+                'id': 'Roads',
                 'layout': {
                     'line-cap': 'round',
-                    'line-join': 'round'
+                    'line-join': 'round',
+                    'visibility': 'visible'
                 },
                 'paint': {
                     'line-color': 'hsl(0, 0%, 97%)',
@@ -114,82 +115,8 @@ export default {
                 'source': 'openmaptiles',
                 'source-layer': 'transportation',
                 'type': 'line',
-                'minzoom': 13,
-                'showButtonLayerToggle': false
-            },
-            {
-                'filter': ['all', ['==', '$type', 'LineString'],
-                    ['in', 'class', 'trunk', 'primary']
-                ],
-                'id': 'road_trunk_primary',
-                'layout': {
-                    'line-cap': 'round',
-                    'line-join': 'round'
-                },
-                'paint': {
-                    'line-color': '#fff',
-                    'line-width': {
-                        'base': 1.4,
-                        'stops': [
-                            [6, 0.5],
-                            [20, 30]
-                        ]
-                    }
-                },
-                'source': 'openmaptiles',
-                'source-layer': 'transportation',
-                'type': 'line',
-                'showButtonLayerToggle': false
-            },
-            {
-                'filter': ['all', ['==', '$type', 'LineString'],
-                    ['in', 'class', 'secondary', 'tertiary']
-                ],
-                'id': 'road_secondary_tertiary',
-                'layout': {
-                    'line-cap': 'round',
-                    'line-join': 'round'
-                },
-                'paint': {
-                    'line-color': '#fff',
-                    'line-width': {
-                        'base': 1.4,
-                        'stops': [
-                            [6, 0.5],
-                            [20, 20]
-                        ]
-                    }
-                },
-                'source': 'openmaptiles',
-                'source-layer': 'transportation',
-                'type': 'line',
-                'showButtonLayerToggle': false
-            },
-            {
-                'filter': ['all', ['==', '$type', 'LineString'],
-                    ['==', 'class', 'motorway']
-                ],
-                'id': 'road_major_motorway',
                 'minzoom': 5,
-                'layout': {
-                    'line-cap': 'round',
-                    'line-join': 'round'
-                },
-                'paint': {
-                    'line-color': 'hsl(0, 0%, 100%)',
-                    'line-offset': 0,
-                    'line-width': {
-                        'base': 1.4,
-                        'stops': [
-                            [8, 1],
-                            [16, 10]
-                        ]
-                    }
-                },
-                'source': 'openmaptiles',
-                'source-layer': 'transportation',
-                'type': 'line',
-                'showButtonLayerToggle': false
+                'showButtonLayerToggle': true
             },
             {
                 'filter': ['all', ['==', '$type', 'Polygon'],


### PR DESCRIPTION
Before making a pull request
----------------------------
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'
- [x] Make sure all tests run
- [x] Update the changelog appropriately

Description
-----------
So was able to combine the roads into one layer call just using their already in place fancy filter, just combined the classes together instead of making separate layers.  The functionality seems untouched, the smaller roads still only show up as you zoom in and line width still seems defined.  It feels too easy, but until I'm proven otherwise I'm running with a simple solution.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial