### PR TITLE
No Data color adjustment

### DIFF
--- a/src/assets/mapStyles/mapStyles.js
+++ b/src/assets/mapStyles/mapStyles.js
@@ -68,7 +68,7 @@ export default {
                             ['average','#C8D3BA'],
                             ['low', '#BDAD9D'],
                             ['very low','#967a4a'],
-                            ['','#000000'],
+                            ['Undefined','rgba(237, 236, 232, 1)']
                         ]
                     },
                     'fill-opacity': ['case',

--- a/src/components/MapLegend.vue
+++ b/src/components/MapLegend.vue
@@ -156,7 +156,7 @@ export default {
           let styleSheetColorLabel = null;
           for (let index = 0; index < styleSheetColorStops.length; index++) {
             // Make a label for the blank and missing data
-            if (styleSheetColorStops[index][0] === "") {
+            if (styleSheetColorStops[index][0] === "Undefined") {
               styleSheetColorLabel = "no data";
             } else {
               styleSheetColorLabel = styleSheetColorStops[index][0];
@@ -186,6 +186,7 @@ export default {
         item.style.margin = "0 0 5px 0";
         item.style.padding = "0 10px 0 0";
         key.style.backgroundColor = color;
+        key.style.border = "1px solid rgb(190,190,190)"
         key.style.margin = " 0 5px 0 10px";
         key.style.display = "inline-block";
         key.style.height = "10px";


### PR DESCRIPTION
Before making a pull request
----------------------------
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'
- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Description
-----------
Even if we don't keep this color, we weren't even hooked up correctly to change the no data HRU's color anyway.  This way we are at least capable of changing it when we wish now.
Also added borders around the legend keys.  Light colors were fading into the legend BG, so this at least helps the eye find all the keys.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial