### PR TITLE
white slivers removal?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- White Slivers Removal (fill-outline)
 - Update styles for updated nhd river tiles 
 - Modify About text and layout
 - Secondary About Button

--- a/src/assets/mapStyles/mapStyles.js
+++ b/src/assets/mapStyles/mapStyles.js
@@ -75,12 +75,7 @@ export default {
                         ['boolean', ['feature-state', 'hover'], false],
                         0.7,
                         1
-                    ],
-                    'fill-outline-color': ['case',
-                        ['boolean', ['feature-state', 'hover'], false],
-                        'rgba(0, 0, 0, 1)',
-                        'rgba(0, 0, 0, 0.0)'
-                    ],
+                    ]
                 },
                 'showButtonLayerToggle': false,
                 'legendText': {


### PR DESCRIPTION
Before making a pull request
----------------------------
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'
- [x] Make sure all tests run
- [x] Update the changelog appropriately

Description
-----------
While playing around with our paint options for the HRU's, I noticed the white slivers stopped being made when I removed the fill-outline-color from the paint property.  The slivers still do show up when zooming in, but are rendered out when mapbox-gl is done rendering the tiles.  

Maybe we just have too many polygons to be using the fill-outline-color?  I couldn't tell you for sure, but it does seem to be the culprit.  We will see what the future brings.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial