### PR TITLE
Change river layer styles to match openmaptiles tiles for rivers/waterbodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Change river layers style to match openmaptiles rivers/waterbodies
 - White Slivers Removal (fill-outline)
 - Update styles for updated nhd river tiles 
 - Modify About text and layout

--- a/src/assets/mapStyles/mapStyles.js
+++ b/src/assets/mapStyles/mapStyles.js
@@ -222,7 +222,7 @@ export default {
                     'visibility': 'none'
                 },
                 'paint': {
-                    'line-color': 'rgba(115, 255, 255, 1)'
+                    'line-color': 'rgba(148, 193, 225, 1)'
                 },
                 'showButtonLayerToggle': false,
                 'showButtonStreamToggle': true
@@ -237,7 +237,7 @@ export default {
                     'visibility': 'none'
                 },
                 'paint': {
-                    'line-color': 'rgba(115, 255, 255, 1)'
+                    'line-color': 'rgba(148, 193, 225, 1)'
                 },
                 'showButtonLayerToggle': false,
                 'showButtonStreamToggle': true
@@ -252,7 +252,7 @@ export default {
                     'visibility': 'none'
                 },
                 'paint': {
-                    'line-color': 'rgba(115, 255, 255, 1)'
+                    'line-color': 'rgba(148, 193, 225, 1)'
                 },
                 'showButtonLayerToggle': false,
                 'showButtonStreamToggle': true,


### PR DESCRIPTION
Before making a pull request
----------------------------
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'
- [ ] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Change river layer styles to match openmaptiles tiles for rivers/waterbodies

Description
-----------
Used the RGB from the openmaptiles waterbodies/rivers 
https://github.com/usgs-makerspace/makerspace-sandbox/issues/212

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial