### PR TITLE
Make stream orders visable past zoom 8

### DIFF
--- a/src/assets/mapStyles/mapStyles.js
+++ b/src/assets/mapStyles/mapStyles.js
@@ -218,6 +218,8 @@ export default {
                 'type': 'line',
                 'source': 'nhd_streams_grouped',
                 'source-layer': 'least_detail',
+                'minzoom': 8,
+                'maxzoom': 24,
                 'layout': {
                     'visibility': 'none'
                 },
@@ -233,6 +235,8 @@ export default {
                 'type': 'line',
                 'source': 'nhd_streams_grouped',
                 'source-layer': 'medium_detail',
+                'minzoom': 8,
+                'maxzoom': 24,
                 'layout': {
                     'visibility': 'none'
                 },
@@ -248,12 +252,15 @@ export default {
                 'type': 'line',
                 'source': 'nhd_streams_grouped',
                 'source-layer': 'most_detail',
+                'minzoom': 8,
+                'maxzoom': 24,
                 'layout': {
                     'visibility': 'none'
                 },
                 'paint': {
                     'line-color': 'rgba(148, 193, 225, 1)'
                 },
+
                 'showButtonLayerToggle': false,
                 'showButtonStreamToggle': true,
             },

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -24,7 +24,10 @@
         href="https://www.usgs.gov/software/precipitation-runoff-modeling-system-prms"
         @click="runGoogleAnalytics('about page', 'click', 'clicked text link for precipitation-runoff-modeling-system-prms')"
       >Precipitation Runoff Modeling
-        System</a> (PRMS; Markstrom et al., 2015). The <a href="http://www.climatologylab.org/gridmet.html" @click="runGoogleAnalytics('about page', 'click', 'clicked text link for gridMET')">gridMET</a> daily weather dataset is used to force both historical and latest-available model runs (Abatzoglou, 2013). The PRMS is a modular, deterministic, distributed-parameter, physical process-based hydrologic simulation code that can be used to evaluate the effects of various combinations of climate and landscape on hydrologic response at the watershed scale  (Regan et al., 2018).The PRMS application of the NHM (NHM-PRMS) is used here to represent the daily water balance across the diverse range of landscapes of the conterminous U.S. Further information on the NHM Infrastructure, the PRMS model, and the NHM-PRMS application can be found in the references below.
+        System</a> (PRMS; Markstrom et al., 2015). The <a
+        href="http://www.climatologylab.org/gridmet.html"
+        @click="runGoogleAnalytics('about page', 'click', 'clicked text link for gridMET')"
+      >gridMET</a> daily weather dataset is used to force both historical and latest-available model runs (Abatzoglou, 2013). The PRMS is a modular, deterministic, distributed-parameter, physical process-based hydrologic simulation code that can be used to evaluate the effects of various combinations of climate and landscape on hydrologic response at the watershed scale  (Regan et al., 2018).The PRMS application of the NHM (NHM-PRMS) is used here to represent the daily water balance across the diverse range of landscapes of the conterminous U.S. Further information on the NHM Infrastructure, the PRMS model, and the NHM-PRMS application can be found in the references below.
     </p>
 
     <h2>About IWAAs</h2>

--- a/src/components/HeaderUSWDSBanner.vue
+++ b/src/components/HeaderUSWDSBanner.vue
@@ -37,7 +37,10 @@
         >
           <div class="grid-row grid-gap-lg">
             <div class="usa-banner__guidance tablet:grid-col-6">
-              <iconDot class="usa-banner__icon usa-media-block__img" alt="Dot gov"/>
+              <iconDot
+                class="usa-banner__icon usa-media-block__img"
+                alt="Dot gov"
+              />
               <div class="usa-media-block__body">
                 <p>
                   <strong>The .gov means it’s official.</strong>
@@ -49,7 +52,10 @@
               </div>
             </div>
             <div class="usa-banner__guidance tablet:grid-col-6">
-              <iconHTTPS class="usa-banner__icon usa-media-block__img" alt="Dot gov"/>
+              <iconHTTPS
+                class="usa-banner__icon usa-media-block__img"
+                alt="Dot gov"
+              />
               <div class="usa-media-block__body">
                 <p>
                   <strong>The site is secure.</strong>

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -6,7 +6,12 @@
           {{ title }} {{ developmentTier }}
         </h1>
         <router-link to="/about">
-          <button id="aboutButton" @click="runGoogleAnalytics('About Button', 'click', 'user went to about page')">About</button>
+          <button
+            id="aboutButton"
+            @click="runGoogleAnalytics('About Button', 'click', 'user went to about page')"
+          >
+            About
+          </button>
         </router-link>
       </div>
     </div>

--- a/vue.config.js
+++ b/vue.config.js
@@ -7,6 +7,5 @@ module.exports = {
         svgRule
                 .use('vue-svg-loader')
                 .loader('vue-svg-loader');
-
     }
 };

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,11 +1,12 @@
 module.exports = {
     chainWebpack: (config) => {
-      const svgRule = config.module.rule('svg');
-  
-      svgRule.uses.clear();
-  
-      svgRule
-        .use('vue-svg-loader')
-        .loader('vue-svg-loader');
+        const svgRule = config.module.rule('svg');
+
+        svgRule.uses.clear();
+
+        svgRule
+                .use('vue-svg-loader')
+                .loader('vue-svg-loader');
+
     }
-  };
+};


### PR DESCRIPTION
Before making a pull request
----------------------------
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'
- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Put Min Zoom on Stream Orders
-----------
Made it so the stream orders will only show on zoom levels of 8-24. 

There were some Tippecanoe compression artifacts for stream orders on zoom levels above 8. We want to hide these from the end user, so I set the zoom level appropriately. 

We will be working more on the streams in temperature prediction part of the WBEEP project, so we will revisit this at a later time. 

P.S. Only the first page of changes are of interest in the review. All the other changes were the result of running 'npm run lint --fix'

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial