### PR TITLE
change to use cloudfront url for hrus

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -4,7 +4,7 @@ VUE_APP_TIER=''
 VUE_APP_ADD_ZOOM_LEVEL_DISPLAY=false
 
 # The URL for the Hydrological Response Unit tiles
-VUE_APP_HRU_TILE_URL=http://wbeep-prod-website.s3-website-us-west-2.amazonaws.com/tiles/{z}/{x}/{y}.pbf?fresh=true
+VUE_APP_HRU_TILE_URL=https://d1drhovb0vmgar.cloudfront.net/tiles/{z}/{x}/{y}.pbf?fresh=true
 
 # The URL for the file that gives us the date of the model data
 VUE_APP_DATA_DATE_URL=https://wbeep-prod-website.s3-us-west-2.amazonaws.com/date/date.txt


### PR DESCRIPTION
Before making a pull request
----------------------------
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'
- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Change to Use CloudFront URL for Production
-----------
Since the public tiers of the application use HTTPS created through CloudFront the browser wants all the resources to also be secure as well, so I switched the hydrologic response unit tile source to use the CloudFront URL of the 'prod' bucket.


After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial