### PR TITLE
changed to secure resources for date and rivers

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -7,4 +7,4 @@ VUE_APP_ADD_ZOOM_LEVEL_DISPLAY=false
 VUE_APP_HRU_TILE_URL=https://d1drhovb0vmgar.cloudfront.net/tiles/{z}/{x}/{y}.pbf?fresh=true
 
 # The URL for the file that gives us the date of the model data
-VUE_APP_DATA_DATE_URL=https://wbeep-prod-website.s3-us-west-2.amazonaws.com/date/date.txt
+VUE_APP_DATA_DATE_URL=https://d1drhovb0vmgar.cloudfront.net/date/date.txt

--- a/src/assets/mapStyles/mapStyles.js
+++ b/src/assets/mapStyles/mapStyles.js
@@ -21,7 +21,7 @@ export default {
             },
             nhd_streams_grouped: {
                 type: 'vector',
-                'tiles':['http://maptiles-prod-website.s3-us-west-2.amazonaws.com/nhdstreams_grouped/{z}/{x}/{y}.pbf'],
+                'tiles':['https://maptiles-prod-website.s3-us-west-2.amazonaws.com/nhdstreams_grouped/{z}/{x}/{y}.pbf'],
                 'minzoom': 2, // setting this to equal the minzoom of main map, real tile extent is 0
                 'maxzoom': 9  // setting this to equal the maxzoom of main map, real tile extent is 10
             },


### PR DESCRIPTION
Before making a pull request
----------------------------
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'
- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Change Model date and NHD Stream Orders to Use Secure Resources
-----------
I switched the call to retrieve the model date to use the CloudFront URL of the 'prod' bucket, and I added an 's' to the 'http' so that it would make an encrypted request to the 'maptiles-prod' tile server bucket.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial