### PR TITLE
Prevent Scrolling

### DIFF
--- a/src/components/LoadingScreen.vue
+++ b/src/components/LoadingScreen.vue
@@ -14,7 +14,14 @@ export default {
   components: {
     USGSLOGO
   },
-  props: {isLoading: Boolean}
+  props: {isLoading: Boolean},
+  mounted(){
+    //prevent user from scrolling this div on mobile
+    var fixed = document.getElementsByClassName("loader");
+    fixed.addEventListener('touchmove', function(e){
+      e.preventDefault();
+    }, false);
+  }
 };
 </script>
 <style lang="scss">

--- a/src/components/LoadingScreen.vue
+++ b/src/components/LoadingScreen.vue
@@ -17,7 +17,7 @@ export default {
   props: {isLoading: Boolean},
   mounted(){
     //prevent user from scrolling this div on mobile
-    var fixed = document.getElementsByClassName("loader");
+    let fixed = document.getElementsByClassName("loader");
     fixed.addEventListener('touchmove', function(e){
       e.preventDefault();
     }, false);


### PR DESCRIPTION
Before making a pull request
----------------------------
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'
- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Description
-----------
Testing on mobile has proven the loading screen to be a bit buggy (nothings ever easy).  One bug being a user can scroll the loading screen and see the map before the loading is complete.  This prevent touchmove on the loading div prevents that and is a less buggy looking mobile experience. 

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial