### PR TITLE
Fix for edge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2487,6 +2487,49 @@
         "resolve": "^1.4.0"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@babel/code-frame": {
           "version": "7.5.5",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+          "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
           "dev": true,
           "requires": {
             "@babel/highlight": "^7.0.0"
@@ -152,7 +152,7 @@
     "@babel/helper-define-map": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
-      "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
+      "integrity": "sha1-PewywgRvN+CbKMk+sLED/Sol02k=",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
@@ -202,7 +202,7 @@
     "@babel/helper-member-expression-to-functions": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
-      "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
+      "integrity": "sha1-H7W47ERTqTxDnun+Ou6kqEt2tZA=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.5.5"
@@ -220,7 +220,7 @@
     "@babel/helper-module-transforms": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
-      "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
+      "integrity": "sha1-+E/4oJA43Lyh/UNVZhpQCTcWW0o=",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -249,7 +249,7 @@
     "@babel/helper-regex": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
-      "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+      "integrity": "sha1-CqaCT3EAouDonBUnwjk2wVLKs1E=",
       "dev": true,
       "requires": {
         "lodash": "^4.17.13"
@@ -271,7 +271,7 @@
     "@babel/helper-replace-supers": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
-      "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
+      "integrity": "sha1-+EzkPfAxIi0rrQaNJibLV5nDS8I=",
       "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.5.5",
@@ -425,7 +425,7 @@
     "@babel/plugin-proposal-class-properties": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz",
-      "integrity": "sha512-AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==",
+      "integrity": "sha1-qXTPrh43wxEOcfPGouSLjnGVjNQ=",
       "dev": true,
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.5.5",
@@ -569,7 +569,7 @@
     "@babel/plugin-transform-async-to-generator": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
-      "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
+      "integrity": "sha1-iaOEigFmYjtbxIEWS1k2q5R+iH4=",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -599,7 +599,7 @@
     "@babel/plugin-transform-classes": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
-      "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
+      "integrity": "sha1-0JQpnZvWgKFKKg7a44MFrWD7Tek=",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
@@ -644,7 +644,7 @@
     "@babel/plugin-transform-duplicate-keys": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
-      "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
+      "integrity": "sha1-xdv1EGv4TN9pEiLAl0wSsd+TGFM=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -700,7 +700,7 @@
     "@babel/plugin-transform-modules-amd": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
-      "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
+      "integrity": "sha1-7wBDXUbaCllhqnKKHS7P8GPk+5E=",
       "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.1.0",
@@ -723,7 +723,7 @@
     "@babel/plugin-transform-modules-systemjs": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
-      "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
+      "integrity": "sha1-51JmoT75QgLbKgYgl3dW9R1S0kk=",
       "dev": true,
       "requires": {
         "@babel/helper-hoist-variables": "^7.4.4",
@@ -762,7 +762,7 @@
     "@babel/plugin-transform-object-super": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
-      "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
+      "integrity": "sha1-xwAh34NAc8ZethO4Z5zEo4HRqfk=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -1371,7 +1371,7 @@
     "@vue/babel-sugar-v-on": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@vue/babel-sugar-v-on/-/babel-sugar-v-on-1.1.0.tgz",
-      "integrity": "sha512-8DwAj/RLpmrDP4eZ3erJcKcyuLArLUYagNODTsSQrMdG5zmLJoFFtEjODfYRh/XxM2wXv9Wxe+HAB41FQxxwQA==",
+      "integrity": "sha1-Hys17uq7h+r4klkx9NNP2OZASkU=",
       "dev": true,
       "requires": {
         "@babel/plugin-syntax-jsx": "^7.2.0",
@@ -1796,7 +1796,7 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
       }
@@ -4734,6 +4734,11 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -4749,7 +4754,7 @@
     "eslint": {
       "version": "5.16.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
-      "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+      "integrity": "sha1-oeOsGq5KP72Clvz496tzFMu2q+o=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -10276,13 +10281,13 @@
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "integrity": "sha1-fPanfY9cb2Drc8X8GVWyzrAea/U=",
       "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
-      "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
+      "integrity": "sha1-Oy/OThq3cywI9mXf2zFHScfd0vs=",
       "dev": true,
       "requires": {
         "private": "^0.1.6"
@@ -11750,15 +11755,6 @@
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
       "dev": true
     },
-    "svg-to-vue": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/svg-to-vue/-/svg-to-vue-0.4.0.tgz",
-      "integrity": "sha512-g/ZHtEFf4QDsDtTk9tuYX/MJ2HESTUBMTkuLoffQGQ3xMtlmD9Ec4YyTgmMkP1P8QJtWWu2FiGdOnlKaXc/X/Q==",
-      "dev": true,
-      "requires": {
-        "svgo": "^1.1.1"
-      }
-    },
     "svgo": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
@@ -11920,7 +11916,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
@@ -13823,13 +13819,15 @@
       }
     },
     "vue-svg-loader": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/vue-svg-loader/-/vue-svg-loader-0.12.0.tgz",
-      "integrity": "sha512-pg8H6iKCj+DAC7FZuxdfGJMHiFpJPv/YyoN1M7Iqlf+Hu4eU6Q/W/sEFx978syQA+aOx0NXrp+uQUAajqQvXbQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/vue-svg-loader/-/vue-svg-loader-0.10.0.tgz",
+      "integrity": "sha512-gfRKKdJ2XskRUkSmXvirz88qQ9Y7ScIzCq+iyXb8CJtSFOT5Le5v/G47riXF3J0IsemUCah7OcCogVDBOkl4jg==",
       "dev": true,
       "requires": {
-        "loader-utils": "^1.2.3",
-        "svg-to-vue": "^0.4.0"
+        "loader-utils": "^1.1.0",
+        "svgo": "^1.1.1",
+        "vue-template-compiler": "^2.5.17",
+        "vue-template-es2015-compiler": "^1.6.0"
       }
     },
     "vue-template-compiler": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.11.2",
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/vue-fontawesome": "^0.1.7",
+    "babel-polyfill": "^6.26.0",
     "core-js": "^3.3.2",
     "dns": "^0.2.2",
     "es6-promise": "^4.2.8",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,13 @@
     "@fortawesome/vue-fontawesome": "^0.1.7",
     "core-js": "^3.3.2",
     "dns": "^0.2.2",
+    "es6-promise": "^4.2.8",
     "mapbox-gl": "^1.4.1",
     "uswds": "^2.2.1",
     "vue": "^2.6.10",
     "vue-analytics": "^5.17.2",
-    "vue-router": "^3.1.3",
-    "vue-mapbox": "^0.4.1"
+    "vue-mapbox": "^0.4.1",
+    "vue-router": "^3.1.3"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.0.4",
@@ -32,7 +33,7 @@
     "eslint-plugin-vue": "^5.2.3",
     "node-sass": "^4.12.0",
     "sass-loader": "^7.3.1",
-    "vue-svg-loader": "^0.12.0",
+    "vue-svg-loader": "^0.10.0",
     "vue-template-compiler": "^2.6.10"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+import 'babel-polyfill'
+import 'es6-promise/auto'
 import Vue from 'vue'
 import VueRouter from 'vue-router'
 import App from './App.vue'


### PR DESCRIPTION
Before making a pull request
----------------------------
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'
- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Fix to Get Internet Explorer 11 Running
-----------
So these changes represent about 20 hours of developer time. Basically there were four intertwining issues that made this perplexing. 1) The need for a polyfill for the ES6 Promises that are used by the Google Analytics plugin. This caused IE 11 to fail and was solved by importing es6-promise polyfill. 2) The newest version of 'vue-svg-loader' has an issue which causes both Edge and IE11 to fail, in the end I was forced to downgrade the version from 0.12.0 to 0.10.0. 3) A similar issue existed for 'core.js' in its latest version, and I was forced to downgrade it to 3.3.2. 4) The 'vue-mapbox' plugin requires a specific trans-piling command in the 'vue.config.js' file so that the newer ES commands it contains will function in both IE11 and Edge. 


After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial