### PR TITLE
changed tile url to match bucket

### DIFF
--- a/.env.beta
+++ b/.env.beta
@@ -4,7 +4,7 @@ VUE_APP_TIER=-beta build-
 VUE_APP_ADD_ZOOM_LEVEL_DISPLAY=false
 
 # The URL for the Hydrological Response Unit tiles
-VUE_APP_HRU_TILE_URL=http://wbeep-test-website.s3-website-us-west-2.amazonaws.com/tiles/{z}/{x}/{y}.pbf?fresh=true
+VUE_APP_HRU_TILE_URL=https://d38anyyapxci3p.cloudfront.net/tiles/{z}/{x}/{y}.pbf?fresh=true
 
 # The URL for the file that gives us the date of the model data
 VUE_APP_DATA_DATE_URL=https://d38anyyapxci3p.cloudfront.net/date/date.txt

--- a/.env.qa
+++ b/.env.qa
@@ -4,7 +4,7 @@ VUE_APP_TIER=-QA build-
 VUE_APP_ADD_ZOOM_LEVEL_DISPLAY=false
 
 # The URL for the Hydrological Response Unit tiles
-VUE_APP_HRU_TILE_URL=http://wbeep-test-website.s3-website-us-west-2.amazonaws.com/tiles/{z}/{x}/{y}.pbf?fresh=true
+VUE_APP_HRU_TILE_URL=http://wbeep-qa-website.s3-website-us-west-2.amazonaws.com/tiles/{z}/{x}/{y}.pbf?fresh=true
 
 # The URL for the file that gives us the date of the model data
 VUE_APP_DATA_DATE_URL=https://wbeep-qa-website.s3-us-west-2.amazonaws.com/date/date.txt


### PR DESCRIPTION
Before making a pull request
----------------------------
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'
- [ ] Make sure all tests run
- [ ] Update the changelog appropriately
- [ ] Run WAVE plugin 508 compliance tool

Change Tile URL to Match Bucket
-----------
Since we are now deploying the Hydrologic Response Unit tiles to directories on each tier, we can change the URL to pull the tiles directly from the tier.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial