### PR TITLE
mapresize solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Map Resize solution
 
 ## [0.0.10]
 - Set up the tiers to use tier-specific resources

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -136,6 +136,9 @@ export default {
 
       let map = event.map; // This gives us access to the map as an object but only after the map has loaded
 
+      //This solves the mysterious whitespace by resizing the map to the correct size.
+      map.resize();
+
       // pinch to zoom for touch devices
       map.touchZoomRotate.enable();
       // disable the rotation functionality, but keep pinch to zoom
@@ -474,6 +477,8 @@ $borderGray: 1px solid rgb(100, 100, 100);
 #mapContainer {
   position: relative;
   height: 80vh;
+  display: flex;
+  flex-direction: column;
 }
 
 @media screen and (min-width: 600px) {
@@ -483,16 +488,11 @@ $borderGray: 1px solid rgb(100, 100, 100);
     flex-direction: column;
   }
 
-  #mapContainer {
+   #mapContainer {
     flex: 1;
-    display: flex;
-    flex-direction: column;
     height: auto;
   }
-  #map {
-    flex: 1;
-    min-height: 70vh;
-  }
+  
 }
 </style>
 <style lang="scss">
@@ -500,6 +500,7 @@ $color: #fff;
 $blue: #4574a3;
 $border: 1px solid rgb(200, 200, 200);
 $background: rgba(255, 255, 255, 0.9);
+
 #mapLayersToggleContainer {
   background: $background;
   border-right: $border;


### PR DESCRIPTION
Before making a pull request
----------------------------
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'
- [x] Make sure all tests run
- [x] Update the changelog appropriately
- [ ] Run WAVE plugin 508 compliance tool

Description
-----------
Found that the USWDS banner seems something to do with the map whitespace on the initial load.  A quick and easy solution is running map.resize() during the map creation.  Maybe doesn't solve the entire mystery, but gets us a better looking product.

Also in my search I found some of my CSS was unnecessary, so less code is always better.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial