### PR TITLE
adding vue router dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13449,6 +13449,11 @@
         "map-promisified": "^0.4.0"
       }
     },
+    "vue-router": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.3.tgz",
+      "integrity": "sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ=="
+    },
     "vue-style-loader": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "vue": "^2.6.10",
     "vue-analytics": "^5.17.5",
     "vue-browser-detect-plugin": "^0.1.5",
-    "vue-mapbox": "^0.4.1"
+    "vue-mapbox": "^0.4.1",
+    "vue-router": "^3.1.3"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.0.5",


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Add Vue-Router as a Project Dependency
-----------
So . . . somehow, Vue-Router was left out of the project and thus the Jenkins' build failed . . . yet the project still ran on my local machine?!

Not really sure how that happens, but I am thinking this will fix it.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial