### PR TITLE
changed names in build back to match jenkins drop down

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
 echo "this is the var $E_VUE_BUILD_MODE"
-if [ "$E_VUE_BUILD_MODE" = "test_tier" ]
+if [ "$E_VUE_BUILD_MODE" = "test" ]
 then npm run build-test
-elif [ "$E_VUE_BUILD_MODE" = "qa_tier" ]
+elif [ "$E_VUE_BUILD_MODE" = "qa" ]
 then npm run build-qa
-elif [ "$E_VUE_BUILD_MODE" = "beta_tier" ]
+elif [ "$E_VUE_BUILD_MODE" = "beta" ]
 then npm run build-beta
 else npm run build
 fi


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Changing the Build Script Names
-----------
I decided not to change the Jenkins job runner drop down menu names, but I forgot that the build script actually matches those and not the 'real' build mode options. So I am changing them back.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial