### PR TITLE
Shrink bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4330,9 +4330,9 @@
       "dev": true
     },
     "ejs": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.2.tgz",
-      "integrity": "sha512-rHGwtpl67oih3xAHbZlpw5rQAt+YV1mSCu2fUZ9XNrfaGEhom7E+AUiMci+ByP4aSfuAWx7hE0BPuJLMrpXwOw==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
+      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
       "dev": true
     },
     "electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -8,16 +8,16 @@
     "IE 11"
   ],
   "scripts": {
-    "serve": "vue-cli-service serve --mode test_tier",
-    "serve-test": "vue-cli-service serve --mode test_tier",
-    "serve-qa": "vue-cli-service serve --mode qa_tier",
-    "serve-beta": "vue-cli-service serve --mode beta_tier",
-    "serve-prod": "vue-cli-service serve --mode prod_tier",
+    "serve": "NODE_ENV=development vue-cli-service serve --mode test_tier",
+    "serve-test": "NODE_ENV=development vue-cli-service serve --mode test_tier",
+    "serve-qa": "NODE_ENV=development vue-cli-service serve --mode qa_tier",
+    "serve-beta": "NODE_ENV=development vue-cli-service serve --mode beta_tier",
+    "serve-prod": "NODE_ENV=development vue-cli-service serve --mode prod_tier",
     "build": "vue-cli-service build --mode prod_tier",
-    "build-test": "vue-cli-service build --mode test_tier",
-    "build-qa": "vue-cli-service build --mode qa_tier",
-    "build-beta": "vue-cli-service build --mode beta_tier",
-    "build-prod": "vue-cli-service build --mode prod_tier",
+    "build-test": "NODE_ENV=production vue-cli-service build --mode test_tier",
+    "build-qa": "NODE_ENV=production vue-cli-service build --mode qa_tier",
+    "build-beta": "NODE_ENV=production vue-cli-service build --mode beta_tier",
+    "build-prod": "NODE_ENV=production vue-cli-service build --mode prod_tier",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
@@ -45,6 +45,7 @@
     "node-sass": "^4.13.0",
     "sass-loader": "^8.0.0",
     "vue-svg-loader": "^0.15.0",
-    "vue-template-compiler": "^2.6.10"
+    "vue-template-compiler": "^2.6.10",
+    "webpack-bundle-analyzer": "^3.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "serve-qa": "NODE_ENV=development vue-cli-service serve --mode qa_tier",
     "serve-beta": "NODE_ENV=development vue-cli-service serve --mode beta_tier",
     "serve-prod": "NODE_ENV=development vue-cli-service serve --mode prod_tier",
-    "build": "vue-cli-service build --mode prod_tier",
+    "build": "NODE_ENV=production vue-cli-service build --mode prod_tier",
     "build-test": "NODE_ENV=production vue-cli-service build --mode test_tier",
     "build-qa": "NODE_ENV=production vue-cli-service build --mode qa_tier",
     "build-beta": "NODE_ENV=production vue-cli-service build --mode beta_tier",

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -119,8 +119,8 @@
                 mapStyle: mapStyles.style,
                 container: "map",
                 zoom: 3,
-                minZoom: 0,
-                maxZoom: 22,
+                minZoom: 2,
+                maxZoom: 6,
                 center: [-95.7129, 37.0902],
                 pitch: 0, // tips the map from 0 to 60 degrees
                 bearing: 0, // starting rotation of the map from 0 to 360

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -119,8 +119,8 @@
                 mapStyle: mapStyles.style,
                 container: "map",
                 zoom: 3,
-                minZoom: 2,
-                maxZoom: 6,
+                minZoom: 0,
+                maxZoom: 22,
                 center: [-95.7129, 37.0902],
                 pitch: 0, // tips the map from 0 to 60 degrees
                 bearing: 0, // starting rotation of the map from 0 to 360

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,11 +1,15 @@
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 module.exports = {
+    configureWebpack: {
+        plugins: [
+            new BundleAnalyzerPlugin()
+        ]
+    },
     publicPath: '.',
     transpileDependencies: ['vue-mapbox'],
     chainWebpack: (config) => {
         const svgRule = config.module.rule('svg');
-
         svgRule.uses.clear();
-
         svgRule
                 .use('babel-loader')
                 .loader('babel-loader')


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Add Explicit NODE_ENV Setting to Package.json Scripts
-----------
Set the NODE_ENV environment variable explicitly 

Description
-----------
Okay, so, yeah. We were seeing a HUGE JavaScript bundle size which was really bogging down the loading of the application. To figure out why, I installed a Webpack plugin called Webpack Bundle Analyzer. This showed that we were having a problem with Font Awesome, and even though we were importing each Font Awesome icon individually, the ENTIRE Font Awesome library was being imported into the final JavaScript bundle making it about four megabytes, ouch.

I dug into this, and it turns out the problem was not Font Awesome but that Webpack was not doing a 'production' build which caused the entire Font Awesome library to be imported into the bundle. When I changed the environment variable file names to match our deployment tiers, that change caused the default behavior of the 'build' command to go from 'production' to 'development'. So, we were ending up with the 'development' bundle going out to our deployment tiers on Amazon Web Services (AWS). 

The semantics of this is all quite confusing. But to attempt to explain, when run 'npm run serve' we always want the 'development' build which generates a huge bundle size but also allow for Hot Module Replacement (instant application reload). And when we run 'npm run build' we always want the 'production' build, which compacts the JavaScript bundle to the smallest size creates a deploy-able version of the application in the 'dist' folder. If you don't change the names of the '.env' files, then this is the default behavior. However, if you do, the default behavior is that 'npm run serve' will behave as above, BUT 'npm run build' will deliver a un-compacted version of the JavaScript bundle to the 'dist' folder. 

To stop Vue from sending a un-compacted JavaScript bundle to the 'dist' folder, which is then sent to AWS , I set the NODE_ENV variable directly in the 'package.json'. The NODE_ENV variable is always in the Vue environment. It is normally allowed to have the default setting Vue assigns, but in our case we can override Vue's choices. The code formerly looked like, "build": "vue-cli-service build --mode prod_tier", now it looks like, "build": "NODE_ENV=production vue-cli-service build --mode prod_tier". 

As a side note, I am not sure if the Jenkins build will tolerate the way the Webpack Bundle Analyzer so I may need to remove it if the build fails.  

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial