### PR TITLE
removed the bundle analyzer plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "node-sass": "^4.13.0",
     "sass-loader": "^8.0.0",
     "vue-svg-loader": "^0.15.0",
-    "vue-template-compiler": "^2.6.10",
-    "webpack-bundle-analyzer": "^3.6.0"
+    "vue-template-compiler": "^2.6.10"
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,10 +1,4 @@
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 module.exports = {
-    configureWebpack: {
-        plugins: [
-            new BundleAnalyzerPlugin()
-        ]
-    },
     publicPath: '.',
     transpileDependencies: ['vue-mapbox'],
     chainWebpack: (config) => {


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Remove Bundle Analyzer Plugin
-----------
I had a feeling this would hang the Jenkins build, and it did.  It is pretty simple to install the plugin when needed, which might be for the best since the way it creates a new browser window at the end of each build (which is what hung Jenkins), could prove annoying at times when you don't care about the JavaScript bundle composition. 

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial