### PR TITLE
Legend tabs alignment on all browsers

### DIFF
--- a/src/components/MapLegend.vue
+++ b/src/components/MapLegend.vue
@@ -242,8 +242,6 @@ $buttonActiveTextColor: #fff;
 }
 
 #tabs {
-  display: flex;
-  flex-direction: column;
   height: 60px;
   width: 25px;
   order: 2;
@@ -253,7 +251,7 @@ $buttonActiveTextColor: #fff;
 }
 
 .tab {
-  flex: 1;
+  height: 30px;
 }
 
 .tabIcon {
@@ -269,7 +267,7 @@ $buttonActiveTextColor: #fff;
   }
 
   svg {
-    margin: 7px 0 0 0;
+    margin: 7px 0 0 0
   }
 }
 
@@ -283,8 +281,10 @@ $buttonActiveTextColor: #fff;
 }
 
 #legendTitle {
-  padding: 5px 5px;
+  padding: 0 5px;
   border-bottom: $border;
+  height: 30px;
+  line-height: 30px;
   p {
     font-size: 0.9em;
   }

--- a/src/components/MapLegend.vue
+++ b/src/components/MapLegend.vue
@@ -267,7 +267,7 @@ $buttonActiveTextColor: #fff;
   }
 
   svg {
-    margin: 7px 0 0 0
+    margin: 7px 0 0 0;
   }
 }
 


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
Flexbox was being too cute with how it was sizing the tabs on browsers, so had to write stricter CSS to prevent the odd looking unaligned line from happening.  Don't like being the strict parent, but gotta be done sometimes.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial