### PR TITLE
Wbeep 310 infobox always on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Set the 'About the Map' information box to by open on page load
 - Set up questions answers page to auto-generate via JSON
 - Removed subtitle modal functionality from MapBox and got it in its own component
 - New Legend and Legend Modal functionality

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,7 @@
     <HeaderUSGS />
     <router-view />
     <FooterEmail />
+    <ProvisionalStatement />
     <FooterUSGS />
   </div>
 </template>
@@ -13,6 +14,7 @@
     import HeaderUSGS from './components/HeaderUSGS'
     import FooterEmail from './components/FooterEmail'
     import FooterUSGS from './components/FooterUSGS'
+    import ProvisionalStatement from "./components/ProvisionalStatement"
 
     export default {
         name: 'App',
@@ -20,6 +22,7 @@
             HeaderUSWDSBanner,
             HeaderUSGS,
             FooterEmail,
+            ProvisionalStatement,
             FooterUSGS
         }
     }

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -1,9 +1,13 @@
 <template>
-  <div id="viz_container">
+  <div
+    id="viz_container"
+    @click.once="toggleAboutMapInfoBox"
+  >
     <LoadingScreen
       v-if="!isInternetExplorer"
       :is-loading="isLoading"
     />
+
     <div class="header-container">
       <div class="usa-prose">
         <h1 class="title-text">
@@ -17,13 +21,11 @@
       id="mapContainer"
     >
       <MapSubtitle
-        v-show="!isAboutTextShowing"
+        :is-about-map-info-box-open="isAboutMapInfoBoxOpen"
+        @clickedInfoIcon="toggleAboutMapInfoBox()"
       />
-      <MapAvailableDataDate
-        v-show="!isAboutTextShowing"
-      />
+      <MapAvailableDataDate />
       <MapLegend
-        v-show="!isAboutTextShowing"
         :legend-title="legendTitle"
       />
       <MglMap
@@ -133,7 +135,7 @@
                 legendTitle: "Latest Natural Water Storage",
                 isLoading: true,
                 isInternetExplorer: false,
-                isAboutTextShowing: false
+                isAboutMapInfoBoxOpen: true,
             };
         },
         created() {
@@ -143,6 +145,9 @@
         methods: {
             runGoogleAnalytics(eventName, action, label) {
                 this.$ga.event(eventName, action, label)
+            },
+            toggleAboutMapInfoBox() {
+                this.isAboutMapInfoBoxOpen = !this.isAboutMapInfoBoxOpen;
             },
             onMapLoaded(event) {
                 let map = event.map; // This gives us access to the map as an object but only after the map has loaded.
@@ -363,6 +368,21 @@
   $blue: #4574a3;
   $border: 1px solid #fff;
   $borderGray: 1px solid rgb(100, 100, 100);
+
+  #overlay {
+    position: fixed; /* Sit on top of the page content */
+    display: none; /* Hidden by default */
+    width: 100%; /* Full width (cover the whole page) */
+    height: 100%; /* Full height (cover the whole page) */
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0,0,0,0.5); /* Black background with opacity */
+    z-index: 2; /* Specify a stack order in case you're using a different order for other elements */
+    cursor: pointer; /* Add a pointer on hover */
+  }
+
   .header-container {
     background-color: #fff;
   }

--- a/src/components/MapSubtitle.vue
+++ b/src/components/MapSubtitle.vue
@@ -7,10 +7,11 @@
       <div id="subtitleInfoButton">
         <a
           id="subtitleIcon"
+          v-ga="$ga.commands.trackName.bind(this, 'button-subtitle', 'click', 'user opened about text box')"
           href="javascript:void(0);"
           aria-label="more information link"
           class="icon"
-          @click="runGoogleAnalytics('subtitle', 'click', 'user opened about text box'), subtitleModalToggle()"
+          @click="$emit('clickedInfoIcon')"
         >
           <font-awesome-icon icon="info" />
         </a>
@@ -18,8 +19,8 @@
     </div>
     <div id="data-date-div" />
     <SubtitleModal
-      v-if="modalShowing"
-      @clickedExit="subtitleModalToggle()"
+      v-if="isAboutMapInfoBoxOpen"
+      @clickedExit="$emit('clickedInfoIcon')"
     />
   </div>
 </template>
@@ -31,18 +32,12 @@ import SubtitleModal from "./SubtitleModal"
     components:{
       SubtitleModal
     },
-    data(){
-      return{
-        modalShowing: false
+    props: {
+      isAboutMapInfoBoxOpen: {
+          type:Boolean,
+          required: true,
+          default: true
       }
-    },
-    methods: {
-        runGoogleAnalytics(eventName, action, label) {
-            this.$ga.event(eventName, action, label)
-        },
-        subtitleModalToggle(){
-          this.modalShowing = !this.modalShowing;
-        }
     }
   };
 </script>
@@ -113,7 +108,6 @@ h2 {
       }
     }
   }
-  
 }
 
 @media screen and (min-width: 600px){
@@ -129,7 +123,5 @@ h2 {
       }
     }
   }
-  
-  
 }
 </style>

--- a/src/components/ProvisionalStatement.vue
+++ b/src/components/ProvisionalStatement.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="usa-prose provisional-statement">
+    <hr>
+    <h5>Provisional Statement</h5>
+    <h6>This information is preliminary or provisional and is subject to revision. It is being provided to meet the need
+      for timely best science. The information has not received final approval by the U.S. Geological Survey (USGS) and
+      is provided on the condition that neither the USGS nor the U.S. Government shall be held liable for any damages
+      resulting from the authorized or unauthorized use of the information.</h6>
+  </div>
+</template>
+
+<script>
+    export default {
+        name: "ProvisionalStatement"
+    }
+</script>
+
+<style scoped lang="scss">
+  .provisional-statement {
+    background-color: #e7f6f8;
+    hr {
+      margin: 0
+    }
+
+    h5 {
+      margin: 0;
+      padding: 0.2em 0.2em 0.25em 0.2em;
+      background-color: #449dac;
+    }
+
+    h6 {
+      padding: 0.2em;
+      margin-top: 0;
+    }
+  }
+
+</style>

--- a/src/components/ProvisionalStatement.vue
+++ b/src/components/ProvisionalStatement.vue
@@ -1,11 +1,12 @@
 <template>
   <div class="usa-prose provisional-statement">
     <hr>
-    <h5>Provisional Statement</h5>
-    <h6>This information is preliminary or provisional and is subject to revision. It is being provided to meet the need
+    <h5>
+      This information is preliminary or provisional and is subject to revision. It is being provided to meet the need
       for timely best science. The information has not received final approval by the U.S. Geological Survey (USGS) and
       is provided on the condition that neither the USGS nor the U.S. Government shall be held liable for any damages
-      resulting from the authorized or unauthorized use of the information.</h6>
+      resulting from the authorized or unauthorized use of the information.
+    </h5>
   </div>
 </template>
 
@@ -23,15 +24,8 @@
     }
 
     h5 {
-      margin: 0;
-      padding: 0.2em 0.2em 0.25em 0.2em;
-      background-color: #449dac;
-    }
-
-    h6 {
       padding: 0.2em;
       margin-top: 0;
     }
   }
-
 </style>

--- a/src/components/SubtitleModal.vue
+++ b/src/components/SubtitleModal.vue
@@ -17,7 +17,7 @@
       </p>
       <router-link to="/questionsandanswers">
         <button
-          @click="runGoogleAnalytics('subtitle', 'click', 'user went to about page')"
+          v-ga="$ga.commands.trackName.bind(this, 'button-subtitle', 'click', 'user went to questions and answers page')"
         >
           Learn More
         </button>

--- a/src/views/QuestionsAndAnswers.vue
+++ b/src/views/QuestionsAndAnswers.vue
@@ -19,7 +19,6 @@
       <h6 class="section-title">
         {{ section.sectionTitle }}
         <router-link
-          v-ga="$ga.commands.trackName.bind(this, 'button-return', 'click', 'user returned to map from questions and answers')"
           to="/"
         >
           <button>
@@ -84,11 +83,6 @@
                 feedbackEmailAddress: process.env.VUE_APP_FEEDBACK_EMAIL_ADDRESS,
                 pageContents: questionsAndAnswers.pageContents
             };
-        },
-        methods: {
-            runGoogleAnalytics(eventName, action, label) {
-                this.$ga.event(eventName, action, label)
-            }
         }
     }
 </script>


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [x] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [x] Edge
- [x] Firefox
- [x] Samsung Internet
- [x] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [x] Update the changelog appropriately

Required Changes to Show Provisional Status
-----------
Added a provisional statement at the bottom and set the 'about this map' informational box to be open when the page is loaded. I also set an event that will close the informational box if a click event happens anywhere in the map area. This only happens once, and the page resumes normal functionality -- until someone goes to the 'questions page' then the process starts over, because the page reloads. 

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial