### PR TITLE
changed to have tiles n date files in nested folder

### DIFF
--- a/.env.beta_tier
+++ b/.env.beta_tier
@@ -4,7 +4,7 @@ VUE_APP_TIER=-beta build-
 VUE_APP_ADD_ZOOM_LEVEL_DISPLAY=false
 
 # The URL for the Hydrological Response Unit tiles
-VUE_APP_HRU_TILE_URL=https://d38anyyapxci3p.cloudfront.net/tiles/{z}/{x}/{y}.pbf?fresh=true
+VUE_APP_HRU_TILE_URL=https://labs-beta.waterdata.usgs.gov/estimated-availability/tiles/{z}/{x}/{y}.pbf?fresh=true
 
 # The URL for the file that gives us the date of the model data
-VUE_APP_DATA_DATE_URL=https://d38anyyapxci3p.cloudfront.net/date/date.txt
+VUE_APP_DATA_DATE_URL=https://labs-beta.waterdata.usgs.gov/estimated-availability/date/date.txt

--- a/.env.prod_tier
+++ b/.env.prod_tier
@@ -4,7 +4,7 @@ VUE_APP_TIER=''
 VUE_APP_ADD_ZOOM_LEVEL_DISPLAY=false
 
 # The URL for the Hydrological Response Unit tiles
-VUE_APP_HRU_TILE_URL=https://d1drhovb0vmgar.cloudfront.net/tiles/{z}/{x}/{y}.pbf?fresh=true
+VUE_APP_HRU_TILE_URL=https://labs.waterdata.usgs.gov/estimated-availability/tiles/{z}/{x}/{y}.pbf?fresh=true
 
 # The URL for the file that gives us the date of the model data
-VUE_APP_DATA_DATE_URL=https://d1drhovb0vmgar.cloudfront.net/date/date.txt
+VUE_APP_DATA_DATE_URL=https://labs.waterdata.usgs.gov/estimated-availability/date/date.txt

--- a/.env.qa_tier
+++ b/.env.qa_tier
@@ -4,7 +4,7 @@ VUE_APP_TIER=-QA build-
 VUE_APP_ADD_ZOOM_LEVEL_DISPLAY=false
 
 # The URL for the Hydrological Response Unit tiles
-VUE_APP_HRU_TILE_URL=http://wbeep-qa-website.s3-website-us-west-2.amazonaws.com/tiles/{z}/{x}/{y}.pbf?fresh=true
+VUE_APP_HRU_TILE_URL=http://wbeep-qa-website.s3-website-us-west-2.amazonaws.com/estimated-availability/tiles/{z}/{x}/{y}.pbf?fresh=true
 
 # The URL for the file that gives us the date of the model data
-VUE_APP_DATA_DATE_URL=https://wbeep-qa-website.s3-us-west-2.amazonaws.com/date/date.txt
+VUE_APP_DATA_DATE_URL=https://wbeep-qa-website.s3-us-west-2.amazonaws.com/estimated-availability/date/date.txt

--- a/.env.test_tier
+++ b/.env.test_tier
@@ -5,6 +5,8 @@ VUE_APP_ADD_ZOOM_LEVEL_DISPLAY=true
 
 # The URL for the Hydrological Response Unit tiles
 VUE_APP_HRU_TILE_URL=http://wbeep-test-website.s3-website-us-west-2.amazonaws.com/tiles/{z}/{x}/{y}.pbf?fresh=true
+# VUE_APP_HRU_TILE_URL=http://wbeep-test-website.s3-website-us-west-2.amazonaws.com/estimated-availability/tiles/{z}/{x}/{y}.pbf?fresh=true
 
 # The URL for the file that gives us the date of the model data
 VUE_APP_DATA_DATE_URL=https://wbeep-test-website.s3-us-west-2.amazonaws.com/date/date.txt
+# VUE_APP_DATA_DATE_URL=https://wbeep-test-website.s3-us-west-2.amazonaws.com/estimated-availability/date/date.txt

--- a/jenkins/Jenkinsfile.build
+++ b/jenkins/Jenkinsfile.build
@@ -64,7 +64,7 @@ pipeline {
                     }
                 }
                 sh """
-                    aws s3 rm "${targetDomain}" --recursive --exclude "tiles/*" --exclude "date/*"
+                    aws s3 rm "${targetDomain}" --recursive --exclude "tiles/*" --exclude "/estimated-availability/tiles/*" --exclude "date/*  --exclude "/estimated-availability/date/*"
                     aws s3 cp "$WORKSPACE/dist" "${targetDomain}"/estimated-availability --recursive
                 """
             }


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Change Prod and Beta to Use the User Friendly URLs
-----------
Changed the file paths so that the 'prod' and 'beta' tier will now make tile and date requests using the user friendly URLs.

Description
-----------
Since there was some suggestions made that the weird CloudFront URLs were 'internal' and that we should not show 'internal' URLs to the world, I switched them to use the 'user friendly URLs'. Of course is not a straight forward thing, since in order to use the 'user friendly URLs' we have to move the date and tiles from the 'root' of the bucket to a nested folder in much the same way we had to move the Vue application. 

To make a long story short, this change will cause problems with us seeing the date and HRUs on any tier where the change was deployed until the tiles and the date are moved to the new nested folder. 

I put the needed change into the code for the 'test' tier, but it is commented out, so that we will maintain full use of 'test'. When the tiles move to the nested folder, we will need to un-comment the new code lines, delete the old and redeploy. 


After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial