### PR TITLE
Provisional statement on mobile

### DIFF
--- a/src/components/ProvisionalStatement.vue
+++ b/src/components/ProvisionalStatement.vue
@@ -2,16 +2,17 @@
   <div class="usa-prose provisional-statement">
     <div v-show="!isFullProvisionalStatementShowing">
       <div class="statement-condensed">
-        <p>
-          This information is PRELIMINARY and PROVISIONAL
-        </p>
-        <button
+        <span>
+          This information is PRELIMINARY and PROVISIONAL 
+          <button
           v-ga="$ga.commands.trackName.bind(this, 'button-provisionalStatement-enlarge', 'click', 'user enlarged the provisional statement')"
           aria-label="learn more about provisional statement"
           @click="toggleProvisionalStatement"
         >
           Learn More
         </button>
+        </span>
+        
       </div>
     </div>
     <div v-show="isFullProvisionalStatementShowing">
@@ -52,13 +53,13 @@
 
 <style scoped lang="scss">
   .provisional-statement {
-    text-align: center;
     font-size: 0.8em;
     margin: auto;
     padding: 0.2em;
     max-width: 70em;
     font-family: 'Avenir', Helvetica, Arial, sans-serif;
     font-weight: 400;
+    text-align: center;
 
     button {
       margin: 3px 0 0 10px;
@@ -72,13 +73,12 @@
     }
 
     .statement-condensed  {
-      P {
-        float: left;
+       display: flex;
+       width: auto;
+      span {
         margin: 5px;
         padding-bottom: 2px;
-      }
-      button {
-        float: left;
+        flex: 5;
       }
     }
 

--- a/src/components/ProvisionalStatement.vue
+++ b/src/components/ProvisionalStatement.vue
@@ -74,7 +74,6 @@
 
     .statement-condensed  {
        display: flex;
-       width: auto;
       span {
         margin: 5px;
         padding-bottom: 2px;


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Description
-----------
Made the condensed statement a span and added the button to it to avoid trying to fight aligning the button and text separately.  

The float that was making the button and text next to each other was acting funky on mobile.  It looked like it had disappeared, but in the end the float was just acting like there was no content and was smooshing the hell out of the div.  I did a quick flexbox fix and everything seems to be working again.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial