### PR TITLE
Add google dimension client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Added ClientId as a custom dimension for Google Analytics
 
 ## [0.1.0]
 - refined the provisional statement

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,10 +2,10 @@
   <div id="app">
     <HeaderUSWDSBanner />
     <HeaderUSGS />
-    <router-view :is-internet-explorer="isInternetExplorer"/>
+    <router-view :is-internet-explorer="isInternetExplorer" />
     <FooterEmail />
     <ProvisionalStatement
-        v-if="!isInternetExplorer"
+      v-if="!isInternetExplorer"
     />
     <FooterUSGS />
   </div>

--- a/src/components/FooterUSGS.vue
+++ b/src/components/FooterUSGS.vue
@@ -133,6 +133,7 @@
         name: 'FooterUSGS',
         methods: {
             runGoogleAnalytics(eventName, action, label) {
+                this.$ga.set({ dimension2: Date.now() });
                 this.$ga.event(eventName, action, label)
             }
         }

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -135,7 +135,8 @@
         },
         methods: {
             runGoogleAnalytics(eventName, action, label) {
-                this.$ga.event(eventName, action, label)
+                this.$ga.set({ dimension2: Date.now() });
+                this.$ga.event(eventName, action, label);
             },
             toggleAboutMapInfoBox() {
                 this.isAboutMapInfoBoxOpen = !this.isAboutMapInfoBoxOpen;

--- a/src/components/MapLayers.vue
+++ b/src/components/MapLayers.vue
@@ -17,6 +17,7 @@ export default {
   },
   methods: {
     runGoogleAnalytics(eventName, action, label) {
+      this.$ga.set({ dimension2: Date.now() });
       this.$ga.event(eventName, action, label)
     },
     createCustomControl(googleAnalytics) {

--- a/src/components/MapLegend.vue
+++ b/src/components/MapLegend.vue
@@ -100,6 +100,7 @@ export default {
   },
   methods: {
     runGoogleAnalytics(eventName, action, label) {
+      this.$ga.set({ dimension2: Date.now() });
       this.$ga.event(eventName, action, label);
     },
     legendToggle(){

--- a/src/components/ProvisionalStatement.vue
+++ b/src/components/ProvisionalStatement.vue
@@ -5,14 +5,13 @@
         <span>
           This information is PRELIMINARY and PROVISIONAL 
           <button
-          v-ga="$ga.commands.trackName.bind(this, 'button-provisionalStatement-enlarge', 'click', 'user enlarged the provisional statement')"
-          aria-label="learn more about provisional statement"
-          @click="toggleProvisionalStatement"
-        >
-          Learn More
-        </button>
+            v-ga="$ga.commands.trackName.bind(this, 'button-provisionalStatement-enlarge', 'click', 'user enlarged the provisional statement')"
+            aria-label="learn more about provisional statement"
+            @click="toggleProvisionalStatement"
+          >
+            Learn More
+          </button>
         </span>
-        
       </div>
     </div>
     <div v-show="isFullProvisionalStatementShowing">

--- a/src/components/QuestionControl.vue
+++ b/src/components/QuestionControl.vue
@@ -17,6 +17,7 @@
         },
         methods: {
             runGoogleAnalytics(eventName, action, label) {
+                this.$ga.set({ dimension2: Date.now() });
                 this.$ga.event(eventName, action, label)
             },
 

--- a/src/main.js
+++ b/src/main.js
@@ -75,15 +75,34 @@ const sessionID = function() {
   });
 };
 
+const clientID = function() {
+  let returnValue;
+  try {
+    returnValue = window.ga.getAll()[10].get('clientId');
+  }
+  catch(error) {
+    console.error('failed to get the ClientId from Google Analytics Cookie, format of Cookie may have changed ');
+    returnValue = null;
+  }
+  return returnValue;
+};
+
 Vue.use(VueAnalytics, {
   id: 'UA-149352326-1',
+  debug: {
+    enabled: false, // default value is 'false'; for more complete output set to true. Just remember to turn it back to 'false' before putting into production.
+    trace: false, // default value is 'false'; for more complete output set to true. Just remember to turn it back to 'false' before putting into production.
+    sendHitTask: true // default value is true. Just leave it as 'true' all the time.
+  },
   set: [
-    { field: 'dimension1', value: sessionID() },
-    { field: 'dimension2', value: Date.now() },
+    { field: 'anonymizeIp', value: true },
+    { field: 'dimension1', value: sessionID() }
   ],
   commands: {
-    trackName (eventName, action, label) {
-      this.$ga.event(eventName, action, label)
+    trackName(eventName, action, label) {
+      this.$ga.set({ dimension2: Date.now() });
+      this.$ga.set({ dimension3: clientID() });
+      this.$ga.event(eventName, action, label);
     }
   },
   router

--- a/src/main.js
+++ b/src/main.js
@@ -75,6 +75,8 @@ const sessionID = function() {
   });
 };
 
+// Next two sections are for Google Analytics
+// First section --  code to get the ClientId from the Google Analytics Cookie
 const clientID = function() {
   let returnValue;
   try {
@@ -86,7 +88,9 @@ const clientID = function() {
   }
   return returnValue;
 };
-
+// Second section -- code to run Vue Analytics plugin
+// Note: to add additional custom dimensions, you must first register the new dimension on the analytics dash board. Then
+// you can set the dimension's value using the plugin.
 Vue.use(VueAnalytics, {
   id: 'UA-149352326-1',
   debug: {
@@ -107,6 +111,7 @@ Vue.use(VueAnalytics, {
   },
   router
 });
+
 
 const app = new Vue({
   router,

--- a/src/main.js
+++ b/src/main.js
@@ -78,7 +78,7 @@ const sessionID = function() {
 const clientID = function() {
   let returnValue;
   try {
-    returnValue = window.ga.getAll()[10].get('clientId');
+    returnValue = window.ga.getAll()[0].get('clientId');
   }
   catch(error) {
     console.error('failed to get the ClientId from Google Analytics Cookie, format of Cookie may have changed ');


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [x] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [x] Edge
- [x] Firefox
- [x] Samsung Internet
- [x] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [x] Update the changelog appropriately

Add Google Analytics Custom Dimension for ClientId
-----------
Added a Google Analytics custom dimension to the dashboard and then extracted the value from the Google Analytics cookie to populate the custom dimension. According to Google, this is not best practice (as they may change the cookie in the future and our code will break), but there does not seem to be a better way to do it right now, and I added a catch that should grab any errors caused by the cookie not having thing where we expect them to be. So at least the application should keep running, minus the ClientId for the analytics.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial