### PR TITLE
added timestamp to the initial vue analytics load

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -100,7 +100,8 @@ Vue.use(VueAnalytics, {
   },
   set: [
     { field: 'anonymizeIp', value: true },
-    { field: 'dimension1', value: sessionID() }
+    { field: 'dimension1', value: sessionID() },
+    { field: 'dimension2', value: Date.now() }
   ],
   commands: {
     trackName(eventName, action, label) {


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Minor Change to Add ClientId to the Initial Vue Analytics Load
-----------
This change just sets the 'timestamp' so that it will be there when the page first loads. Any click events after the first load will reset the timestamp.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial