### PR TITLE
Subtitle mobile fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-
+- New Flexible Mobile Subtitle
 
 ## [0.1.2]
 - modify svg to drop xlink:href to png image which is unnecessary

--- a/src/components/MapAvailableDataDate.vue
+++ b/src/components/MapAvailableDataDate.vue
@@ -4,7 +4,7 @@
     class="subtitle"
   >
     <div class="subtitleText">
-      <p>Showing Latest Available Data: {{ dataDate }}</p>
+      <p>Showing Latest Available Data: <span class="nowrap"><strong>{{ dataDate }}</strong></span></p>
     </div>
   </div>
 </template>
@@ -34,9 +34,9 @@
 <style scoped lang="scss">
   .subtitle {
     background: rgb(255, 255, 255);
-    background: rgba(255, 255, 255, 0.7);
+    background: rgba(255, 255, 255, 0.8);
     position: absolute;
-    top: 43px;
+    top: 47px;
     left: 50%;
     transform: translateX(-50%);
     z-index: 1;
@@ -45,7 +45,8 @@
     flex-direction: row;
     text-align: center;
     border: 1px solid rgb(200, 200, 200);
-    width:270px;
+    width: 70%;
+    max-width: 260px;
 
 
     p {
@@ -54,10 +55,21 @@
       font-size: .75em;
     }
 
+    .nowrap{
+      white-space: pre;
+    }
+
     .subtitleText {
       flex: 1;
-      line-height: 25px;
-      padding: 0;
+      line-height: 20px;
+      padding: 2px;
     }
   }
+  @media screen and (min-width: 600px) {
+  .subtitle {
+    p {
+      font-size: 0.8em;
+    }
+  }
+}
 </style>

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -461,8 +461,8 @@
 
   #mapContainer {
     position: relative;
-    height: 90vh;
-    min-height: 600px;
+    height: 80vh;
+    min-height: 550px;
     display: flex;
     flex-direction: column;
   }

--- a/src/components/MapSubtitle.vue
+++ b/src/components/MapSubtitle.vue
@@ -18,7 +18,10 @@
       </div>
     </div>
     <div id="data-date-div" />
-    <SubtitleModal v-if="isAboutMapInfoBoxOpen" @clickedExit="$emit('clickedInfoIcon')" />
+    <SubtitleModal
+      v-if="isAboutMapInfoBoxOpen"
+      @clickedExit="$emit('clickedInfoIcon')"
+    />
   </div>
 </template>
 

--- a/src/components/MapSubtitle.vue
+++ b/src/components/MapSubtitle.vue
@@ -18,109 +18,114 @@
       </div>
     </div>
     <div id="data-date-div" />
-    <SubtitleModal
-      v-if="isAboutMapInfoBoxOpen"
-      @clickedExit="$emit('clickedInfoIcon')"
-    />
+    <SubtitleModal v-if="isAboutMapInfoBoxOpen" @clickedExit="$emit('clickedInfoIcon')" />
   </div>
 </template>
 
 <script>
-import SubtitleModal from "./SubtitleModal"
-  export default {
-    name: "MapSubtitle",
-    components:{
-      SubtitleModal
-    },
-    props: {
-      isAboutMapInfoBoxOpen: {
-          type:Boolean,
-          required: true,
-          default: true
-      }
+import SubtitleModal from "./SubtitleModal";
+export default {
+  name: "MapSubtitle",
+  components: {
+    SubtitleModal
+  },
+  props: {
+    isAboutMapInfoBoxOpen: {
+      type: Boolean,
+      required: true,
+      default: true
     }
-  };
+  }
+};
 </script>
 
 <style scoped lang="scss">
-h2 {
-  font-size: 1.1rem;
-}
-
-#subTitleContainer{
+#subTitleContainer {
   position: absolute;
   top: 10px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 1;
+  width: 70%;
+  max-width: 260px;
 }
 
 #subtitle {
   background: rgb(255, 255, 255);
-  background: rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.8);
   position: relative;
   border-radius: 5px;
   display: flex;
-  flex-direction: row;
   text-align: center;
   border: 1px solid rgb(200, 200, 200);
-  width:270px;
 
   p {
     margin: 0;
     user-select: none;
-    font-size:.8em;
+    font-size: 0.75em;
   }
 
   #subtitleText {
-    flex: 1;
-    line-height: 30px;
-    padding: 0 0 0 10px;
+    flex: 9;
+    p {
+      padding: 5px 5px;
+    }
   }
 
   #subtitleInfoButton {
-    margin: 0 0 0 10px;
-    width: 30px;
-    height: 30px;
-    position: relative;
-    border-left: 1px solid rgb(200,200,200);
+    border-left: 1px solid rgb(200, 200, 200);
+    flex: 1;
 
-    a{
+    #subtitleIcon {
+      display: inline-block;
+      border-radius: 0 5px 5px 0;
+      width: 100%;
+      height: 100%;
       color: #000;
       outline: none;
-    }
 
-    #subtitleIcon{
-      display: block;
-      height: 100%;
-      border-radius: 0 5px 5px 0;
+      &:hover{
+        color:#fff;
+        background: #003366;
+      }
 
-      &:active{
+      &:active {
         background: #003366;
         color: #ffffff;
       }
-      
 
-      svg{
+      svg {
         width: 18px;
         height: 18px;
-        margin: 5px 0 0 0;
+        margin: 9px 0 0 0;
       }
     }
   }
 }
 
-@media screen and (min-width: 600px){
-  #subtitle{
-    width: 320px;
-
-    p{
-      font-size: .9em;
-    }
-    #subtitleInfoModal{
-      #infoContainer{
-        width: 320px;
+@media screen and (min-width: 360px) {
+  #subtitle {
+    #subtitleText {
+      line-height: 30px;
+      p {
+        padding: 0 5px;
       }
+    }
+
+    #subtitleInfoButton {
+      #subtitleIcon {
+        svg {
+          margin: 5px 0 0 0;
+        }
+      }
+    }
+  }
+}
+
+@media screen and (min-width: 600px) {
+  #subtitle {
+    p {
+      font-size: 0.8em;
     }
   }
 }

--- a/src/components/SubtitleModal.vue
+++ b/src/components/SubtitleModal.vue
@@ -1,15 +1,17 @@
 <template>
   <div id="subtitleInfoModal">
     <div id="infoContainer">
-      <a
-        id="exit"
-        href="javascript:void(0);"
-        aria-label="close more information box"
-        class="icon"
-        @click="$emit('clickedExit')"
-      >
-        <font-awesome-icon icon="times" />
-      </a>
+      <div id="subtitleModalExit">
+        <a
+          id="exit"
+          href="javascript:void(0);"
+          aria-label="close more information box"
+          class="icon"
+          @click="$emit('clickedExit')"
+        >
+          <font-awesome-icon icon="times" />
+        </a>
+      </div>
       <h2>About This Map</h2>
       <p>
         This map shows the latest available daily estimates of natural water storage for approximately 110,000 regions across the conterminous U.S.
@@ -18,87 +20,85 @@
       <router-link to="/questionsandanswers">
         <button
           v-ga="$ga.commands.trackName.bind(this, 'button-subtitle', 'click', 'user went to questions and answers page')"
-        >
-          Learn More
-        </button>
+        >Learn More</button>
       </router-link>
     </div>
   </div>
 </template>
 <script>
 export default {
-    name: "SubTitleModal"
+  name: "SubTitleModal"
 };
 </script>
 <style scoped lang="scss">
-#subtitleInfoModal{
-    min-height: 30px;
-    position: absolute;
-    top: 65px;
-    z-index: 1000;
-    border-radius: 5px;
-    border: 1px solid rgb(200,200,200);
-    background: rgb(255,255,255);
-    background: rgba(255,255,255,.8);
-    
-    #infoContainer{
-      min-height: 20px;
-      width: 270px;
-      position: relative;
-      padding: 25px 10px 0 10px;
-      font-size: .9em;
+#subtitleInfoModal {
+  min-height: 30px;
+  position: absolute;
+  top: 85px;
+  z-index: 1000;
+  border-radius: 5px;
+  border: 1px solid rgb(200, 200, 200);
+  background: rgb(255, 255, 255);
+  background: rgba(255, 255, 255, 0.8);
+
+  #infoContainer {
+    min-height: 20px;
+    position: relative;
+    padding: 20px 5x 0 5px;
+    font-size: 0.9em;
+    text-align: center;
+    max-width: 260px;
+
+    #subtitleModalExit{
+      text-align: right;
+    }
+
+    #exit {
+      display: inline-block;
+      width: 25px;
+      height: 100%;
+      color: #000;
+      cursor: pointer;
+      outline: none;
       text-align: center;
 
-      #exit{
-        display: inline-block;
-        width: 18px;
+      svg {
         height: 18px;
-        position: absolute;
-        right: 5px;
-        top: 3px;
-        text-align: center;
-        color: #000;
-        cursor: pointer;
-        outline: none;
-
-        svg{
-            height: 100%;
-            width: 100%;
-            margin: 3px 0 0 0;
-        }
-      }
-
-      p{
-        text-align: left;
-        margin: 0 0 10px 0;
-      }
-      
-      h2{
-        font-size: 1.2em;
-        font-weight: bold;
-        padding: 0;
-        margin: 8px 0;
-      }
-
-      button{
-        margin: 0 0 10px 0;
-        background: #003366;
-        color: #ffffff;
-        border: none;
-        outline: none;
-        padding: 5px 10px;
-        border-radius: 5px;
-        font-size: .9em;
-        font-weight: bold;
+        width: 18px;
+        margin: 3px 0 0 0;
       }
     }
-  }
 
-  @media screen and (min-width: 600px){
-      #subtitleInfoModal{
-        #infoContainer{
-            width: 320px;
-        }
+    p {
+      text-align: left;
+      margin: 0 0 10px 0;
+      padding: 0 10px;
+    }
+
+    h2 {
+      font-size: 1.2em;
+      font-weight: bold;
+      padding: 0;
+      margin: 8px 0;
+    }
+
+    button {
+      margin: 0 0 10px 0;
+      background: #003366;
+      color: #ffffff;
+      border: none;
+      outline: none;
+      padding: 5px 10px;
+      border-radius: 5px;
+      font-size: 0.9em;
+      font-weight: bold;
+    }
+  }
+}
+
+@media screen and (min-width: 360px){
+    #subtitleInfoModal{
+      top: 70px;
     }
   }
 </style>

--- a/src/components/SubtitleModal.vue
+++ b/src/components/SubtitleModal.vue
@@ -20,7 +20,9 @@
       <router-link to="/questionsandanswers">
         <button
           v-ga="$ga.commands.trackName.bind(this, 'button-subtitle', 'click', 'user went to questions and answers page')"
-        >Learn More</button>
+        >
+          Learn More
+        </button>
       </router-link>
     </div>
   </div>


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [x] Edge
- [x] Firefox
- [x] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [x] Update the changelog appropriately

Description
-----------
Subtitle was improperly formatting itself when faced with a lack of space.  Some adjustments to how the CSS is formed has fixed this.  

Other changes is the min-height to the map container, as I saw old iphones could never get the full map on their tiny phones at once. Also bolded the date in the subtitle date module.  Seems more important now, but can always be reverted.  finally added a white-space: pre on the date, so it never shifts dumbly like 12-
09-19

^ Cause thats dumb looking 

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial