### PR TITLE
Fix double click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fixed bug requiring double click on info text close box
 - New Flexible Mobile Subtitle
 
 ## [0.1.2]

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     id="viz_container"
-    @click.once="toggleAboutMapInfoBox"
+    @click.once="clickAnywhereToCloseMapInfoBox"
   >
     <LoadingScreen
       v-if="!isInternetExplorer"
@@ -22,7 +22,8 @@
     >
       <MapSubtitle
         :is-about-map-info-box-open="isAboutMapInfoBoxOpen"
-        @clickedInfoIcon="toggleAboutMapInfoBox()"
+        @clickedInfoIcon="clickAnywhereToCloseMapInfoBox()"
+        @clickedExit="toggleMapInfoBox()"
       />
       <MapAvailableDataDate />
       <MapLegend
@@ -130,7 +131,8 @@
                 maxBounds: [[-179.56055624999985, 9.838930211369288], [-11.865243750001127, 57.20768307316615]], // The coordinates needed to make a bounding box for the continental United States.
                 legendTitle: "Latest Natural Water Storage",
                 isLoading: true,
-                isAboutMapInfoBoxOpen: true
+                isAboutMapInfoBoxOpen: true,
+                isFirstClick: true
             };
         },
         methods: {
@@ -138,9 +140,14 @@
                 this.$ga.set({ dimension2: Date.now() });
                 this.$ga.event(eventName, action, label);
             },
-            toggleAboutMapInfoBox() {
-                console.log('ran the toggle')
+            clickAnywhereToCloseMapInfoBox() {
                 this.isAboutMapInfoBoxOpen = !this.isAboutMapInfoBoxOpen;
+                this.isFirstClick = false;
+            },
+            toggleMapInfoBox() {
+                if (!this.isFirstClick) {
+                    this.isAboutMapInfoBoxOpen = !this.isAboutMapInfoBoxOpen;
+                }
             },
             onMapLoaded(event) {
                 let map = event.map; // This gives us access to the map as an object but only after the map has loaded.

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -139,6 +139,7 @@
                 this.$ga.event(eventName, action, label);
             },
             toggleAboutMapInfoBox() {
+                console.log('ran the toggle')
                 this.isAboutMapInfoBoxOpen = !this.isAboutMapInfoBoxOpen;
             },
             onMapLoaded(event) {

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -22,7 +22,7 @@
     >
       <MapSubtitle
         :is-about-map-info-box-open="isAboutMapInfoBoxOpen"
-        @clickedInfoIcon="clickAnywhereToCloseMapInfoBox()"
+        @clickedInfoIcon="toggleMapInfoBox()"
         @clickedExit="toggleMapInfoBox()"
       />
       <MapAvailableDataDate />

--- a/src/components/MapSubtitle.vue
+++ b/src/components/MapSubtitle.vue
@@ -20,7 +20,7 @@
     <div id="data-date-div" />
     <SubtitleModal
       v-if="isAboutMapInfoBoxOpen"
-      @clickedExit="$emit('clickedInfoIcon')"
+      @clickedExit="$emit('clickedExit')"
     />
   </div>
 </template>


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [x] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [x] Edge
- [x] Firefox
- [x] Samsung Internet
- [x] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [x] Update the changelog appropriately

Fix Bug Requiring Double Click to Close Map Info Box
-----------
When the user clicked on the map info close box, it triggered both the close box click and the click 'anywhere' click, which basically closed then reopened the info box before the user could see a change, making appear as if it did not close. I added some conditional logic that to stop the second click event from toggling the box on the first event.   So, all should be okay now.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial