### PR TITLE
Map Bounding Box Tweak for Mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Map Bounding Box For Mobile 
 - Fixed bug requiring double click on info text close box
 - New Flexible Mobile Subtitle
 

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -123,7 +123,7 @@
                 container: "map",
                 zoom: 2,
                 minZoom: 2,
-                maxZoom: 5.99,
+                maxZoom: 6,
                 center: [-95.7129, 37.0902],
                 pitch: 0, // tips the map from 0 to 60 degrees
                 bearing: 0, // starting rotation of the map from 0 to 360

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -121,14 +121,14 @@
                 developmentTier: process.env.VUE_APP_TIER,
                 mapStyle: mapStyles.style,
                 container: "map",
-                zoom: 3,
+                zoom: 2,
                 minZoom: 2,
-                maxZoom: 6,
+                maxZoom: 5.99,
                 center: [-95.7129, 37.0902],
                 pitch: 0, // tips the map from 0 to 60 degrees
                 bearing: 0, // starting rotation of the map from 0 to 360
                 hoveredHRUId: null,
-                maxBounds: [[-179.56055624999985, 9.838930211369288], [-11.865243750001127, 57.20768307316615]], // The coordinates needed to make a bounding box for the continental United States.
+                maxBounds: [[-168.534393,-4.371744], [-19.832382,71.687625]], // The coordinates needed to make a bounding box for the continental United States.
                 legendTitle: "Latest Natural Water Storage",
                 isLoading: true,
                 isAboutMapInfoBoxOpen: true,


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [x] Edge
- [x] Firefox
- [x] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [x] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
Was able to use a pretty cool bounding box tool to find a bounding box that allows us to zoom out enough for mobile and fitbounds, but doesn't allow the user to pan all over the globe.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial