### PR TITLE
Blue background fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Quick Map BG Appearing Fix
 - Map Bounding Box For Mobile 
 - Fixed bug requiring double click on info text close box
 - New Flexible Mobile Subtitle

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -123,7 +123,7 @@
                 container: "map",
                 zoom: 2,
                 minZoom: 2,
-                maxZoom: 6,
+                maxZoom: 5.99,
                 center: [-95.7129, 37.0902],
                 pitch: 0, // tips the map from 0 to 60 degrees
                 bearing: 0, // starting rotation of the map from 0 to 360


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [x] Edge
- [x] Firefox
- [x] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
We discovered its actually the openmaptiles disappearing not the BG layer.  I was under the impression the BG layer was blue, but it is currently cream.  So for now stopping the zoom from going in the last .01 zoom that the openmaptiles disappear.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial