### PR TITLE
contiuous color ramp using mapbox expressions

### DIFF
--- a/src/assets/mapStyles/waterTemperature/mapStyles.js
+++ b/src/assets/mapStyles/waterTemperature/mapStyles.js
@@ -249,12 +249,18 @@ export default {
                 'source': 'streams',
                 'source-layer': 'segsAllConus',
                 'minzoom': 0,
-                'maxzoom': 6,
+                'maxzoom': 15,
                 'layout': {
                     'visibility': 'visible'
                 },
                 'paint': {
-                    'line-color': 'rgba(148, 193, 225, 1)'
+                    'line-width': 1,
+                    'line-color': [
+                        "rgb",
+                        ["*", 5.6, ["get", "temp"]], // value for red parameter
+                        ["+", 50, ["*", 3.93, ["get", "temp"]]], // value for green parameter
+                        ["-", 168, ["*", 3.93, ["get", "temp"]]] // value for blue parameter
+                    ]
                 }
             },
             {

--- a/src/views/waterTemperature/WaterTemperature.vue
+++ b/src/views/waterTemperature/WaterTemperature.vue
@@ -58,7 +58,6 @@
 
 
     import MapLayers from "../../components/MapLayers";
-    import { icon } from "@fortawesome/fontawesome-svg-core";
     import QuestionControl from "../../components/QuestionControl";
 
     import {
@@ -94,7 +93,7 @@
                 container: 'map',
                 zoom: 2,
                 minZoom: 2,
-                maxZoom: 5.99,
+                maxZoom: 15,
                 center: [-95.7129, 37.0902],
                 pitch: 0, // tips the map from 0 to 60 degrees
                 bearing: 0, // starting rotation of the map from 0 to 360


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Example of Mapbox Expressions
-----------
This uses Mapbox expressions to generate an 'infinite' range of colors based on the value of the data. This is not intended to be the final version of this issue but more of an example of both Mapbox expressions to make the color range and the a continuous color ramp.



After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial