### PR TITLE
added change to keep current header on all but test tier

### DIFF
--- a/src/views/waterStorage/WaterStorage.vue
+++ b/src/views/waterStorage/WaterStorage.vue
@@ -6,6 +6,16 @@
     <LoadingScreen
       :is-loading="isLoading"
     />
+    <div
+        v-if="developmentTier !== '-test build-'"
+        class="header-container"
+    >
+      <div class="usa-prose">
+        <h1>
+          {{ title }} {{ featureName }}{{ titleSuffix }} {{ developmentTier }}
+        </h1>
+      </div>
+    </div>
     <div id="mapContainer">
       <MapSubtitle
         :is-about-map-info-box-open="isAboutMapInfoBoxOpen"
@@ -407,6 +417,20 @@
   #layers,
   #streams{
     display: none;
+  }
+
+  .usa-prose {
+    border-bottom: $borderGray;
+    display: flex;
+    h1 {
+      font-size: 1rem;
+      margin-left: 10px;
+      flex: 1;
+    }
+    a{
+      margin: 0;
+      display: block;
+    }
   }
 
   #aboutButton{


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Fix - this keeps the old header on all the tiers except 'test
-----------
When changing the header, I forgot that we wanted to keep the old WBEEP-Water-Storage available for updating but still hide the new features from users. This change keeps that capability.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial