### PR TITLE
Add an example d3 radial chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- added initial d3 code for a radial chart for thermoelectric water use data
 - updated feature navigation styles
 - wateruse animation data moved to s3
 - draft of wateruse animation

--- a/src/components/waterUse/RadialChart.vue
+++ b/src/components/waterUse/RadialChart.vue
@@ -1,17 +1,72 @@
 <template>
   <div>
-    <h1>Add any needed HTML here</h1>
+    <!-- Add any needed HTML here  -->
   </div>
 </template>
 <script>
 //Any data needed can be imported here
+import * as d3 from "d3";
+
 export default {
     'name': 'radialChart',
     mounted(){
-        //Add Code Here
+        var w = 300, h = 300;
+        var viz = d3.select("#radialCharts").append("div").append("svg").attr("width", w).attr("height", h);
+
+        // circle math constants (assuming that Jan 1 = top of circle and moving clockwise)
+        var centroid_x = 150, centroid_y = 150,
+            angle_per_day = 2*Math.PI/365,
+            inner_r = 50,
+            bar_length_max = 125,
+            bar_length_min = 0;
+        
+        function add_bars(data) {
+
+            var wu_min = d3.min(data, d => d.wu_total),
+                wu_max = d3.max(data, d => d.wu_total);
+
+            data.forEach(function(d) {
+                d.wu_rescaled = ( ((d.wu_total - wu_min) * (bar_length_max - bar_length_min)) / (wu_max - wu_min) ) + bar_length_min;
+                d.angle = (Math.PI/2 - angle_per_day*(d.day_nu - 1)); // calculate the angle from the top of the circle to the day
+                d.x1 = centroid_x + inner_r*Math.cos(d.angle); // x position on the inner circle to start the line segment representing wu
+                d.y1 = centroid_y + inner_r*-Math.sin(d.angle); // y position on the inner circle to start the line segment representing wu
+                d.x2 = d.x1 + d.wu_rescaled*Math.cos(d.angle); // x position to end the line segment for each day (based on WU value)
+                d.y2 = d.y1 + d.wu_rescaled*-Math.sin(d.angle); // y position to end the line segment for each day (based on WU value)
+            });
+            
+            viz.append("g").selectAll("line")
+              .data(data)
+              .enter()
+              .append("line")
+              .attr("stroke","grey")
+              .attr("stroke-width","1")
+              .attr("x1", function(d) {return d.x1})
+              .attr("y1", function(d) {return d.y1})
+              .attr("x2", function(d) {return d.x2})
+              .attr("y2", function(d) {return d.y2});
+        }
+
+        // Add Thermoelectric radial chart
+        d3.csv("https://maptiles-prod-website.s3-us-west-2.amazonaws.com/misc/WBEEPWaterUse/te_bar_data.csv").then(function(data) {
+            return add_bars(data);
+        });
+
+        // maybe the start of how the time ticker gets added
+        viz.append("line")
+            .attr("stroke", "pink")
+            .attr("x1", centroid_x)
+            .attr("y1", centroid_y - inner_r)
+            .attr("x2", centroid_x)
+            .attr("y2", centroid_y - inner_r - 225);
+        
+        // add class to SVG so keep that area small compared to map
+        viz.attr("class", "radial_area")
+
     }
 }
 </script>
 <style lang='scss'>
- /*####CSS HERE######*/
+  .radial_area {
+    max-height: 500 px
+  }
 </style>

--- a/src/components/waterUse/RadialChart.vue
+++ b/src/components/waterUse/RadialChart.vue
@@ -16,8 +16,8 @@ export default {
         // circle math constants (assuming that Jan 1 = top of circle and moving clockwise)
         var centroid_x = 150, centroid_y = 150,
             angle_per_day = 2*Math.PI/365,
-            inner_r = 50,
-            bar_length_max = 125,
+            inner_r = 40,
+            bar_length_max = 100,
             bar_length_min = 0;
         
         function add_bars(data) {

--- a/src/views/waterUse/WaterUse.vue
+++ b/src/views/waterUse/WaterUse.vue
@@ -5,6 +5,9 @@
     <div id="waterUseVisualArea">
       <div id="radialCharts">
         <RadialCharts />
+        <button id="animate" @click="CreateAnimatingLocations()" >
+          Animate Map
+        </button>
       </div>
       <div id="waterUseMap">
         <div id="day" />


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [x] Update the changelog appropriately

Add the d3 radial chart placeholder into water-use view
-----------
Added a d3 solution for the radial charts to the water-use view above the map. Still working on mock-ups for what the radial charts look like in the end, but at least there is some code to start with. Also, added the button back in that got deleted in https://github.com/usgs-makerspace/wbeep-viz/pull/381. This work addresses https://github.com/usgs-makerspace/makerspace-sandbox/issues/475.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial