### PR TITLE
make loading screen changes work on both test and qa builds

### DIFF
--- a/src/components/ApplicationFeatureSelection.vue
+++ b/src/components/ApplicationFeatureSelection.vue
@@ -164,3 +164,9 @@
   }
 }
 </style>
+<style lang="scss">
+.loader {
+  top: 129px;
+  height: 75%;
+}
+</style>

--- a/src/components/LoadingScreenInternal.vue
+++ b/src/components/LoadingScreenInternal.vue
@@ -42,9 +42,9 @@ export default {
   position: fixed;
   right: 0;
   text-align: center;
-  top: 129px;
+  top: 0;
   z-index: 9000;
-  height: 75%;
+  height: 100%;
 }
 
 .stop-scrolling { 

--- a/src/views/waterStorage/WaterStorage.vue
+++ b/src/views/waterStorage/WaterStorage.vue
@@ -476,6 +476,11 @@
   $border: 1px solid rgb(200, 200, 200);
   $background: rgba(255, 255, 255, 0.9);
 
+  .loader {
+    top: 127px;
+    height: 75%;
+  }
+
   #mapLayersToggleContainer {
     background: $background;
     border-right: $border;

--- a/src/views/waterTemperature/WaterTemperature.vue
+++ b/src/views/waterTemperature/WaterTemperature.vue
@@ -820,3 +820,9 @@
     }
   }
 </style>
+<style lang="scss">
+.loader {
+  top: 107px;
+  height: 100%;
+}
+</style>

--- a/src/views/waterUse/WaterUse.vue
+++ b/src/views/waterUse/WaterUse.vue
@@ -220,6 +220,11 @@
 </script>
 
 <style lang="scss">
+.loader {
+  top: 107px;
+  height: 100%;
+}
+
 #water-use-container {
   border: solid black;
   border-width: 0 1px 1px 1px;


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
https://github.com/usgs-makerspace/makerspace-sandbox/issues/571
only show the partial splash screen on pages where the nav bar shows. accommodate QA build to make sure it works on both deployments 

Description
-----------
modified the css in the ApplicationFeatureSelection vue file so that when this component is active (regardless of tier) it adjusts the splash screen to accommodate the nav bar
in turn, when that is not present, modifed the css in each of the page vue files to do the same. it will work both on tiers that are told to show the nav bar as well as those who do not with these changes. also on the water temp and water use pages, don't cut off at 75% (to show footer) since their layouts are different.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial