### PR TITLE
use interpolation between zoom levels to determine line thickness

### DIFF
--- a/src/assets/mapStyles/waterTemperature/mapStyles.js
+++ b/src/assets/mapStyles/waterTemperature/mapStyles.js
@@ -206,7 +206,7 @@ export default {
                 'type': 'raster',
                 'source': 'hillshade',
                 'layout': {
-                    'visibility': 'visible'
+                    'visibility': 'none'
                 },
                 'showButtonLayerToggle': true,
                 'showButtonStreamToggle': false,
@@ -296,12 +296,17 @@ export default {
                 },
                 'filter': ["all", ["has", "temp"]],
                 "paint": {
-                    "line-width": 1,
+                    "line-width": [
+                        "interpolate", 
+                        ["linear"], ["zoom"],
+                        4, 1,
+                        7, 5
+                    ],
                     "line-color": [
                         "interpolate", ["linear"], ["get", "temp"],
                         0, "#10305d", 
-                        12.48, "#c4c1b6",
-                        27.04, "#730000"
+                        14.08, "#c4c1b6",
+                        25.88, "#730000"
                     ]
                   }
 

--- a/src/assets/mapStyles/waterTemperature/mapStyles.js
+++ b/src/assets/mapStyles/waterTemperature/mapStyles.js
@@ -206,7 +206,7 @@ export default {
                 'type': 'raster',
                 'source': 'hillshade',
                 'layout': {
-                    'visibility': 'none'
+                    'visibility': 'visible'
                 },
                 'showButtonLayerToggle': true,
                 'showButtonStreamToggle': false,


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
change the line width on streams_interpolated layer so that they adjust with zoom level

Description
-----------
added an expression so that as the user zooms the line thickness on the rivers get wider

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial