### PR TITLE
limit zoom level for stream layers to 6

### DIFF
--- a/src/assets/mapStyles/waterTemperature/mapStyles.js
+++ b/src/assets/mapStyles/waterTemperature/mapStyles.js
@@ -30,7 +30,7 @@ export default {
                 type: 'vector',
                 'tiles': streamsTileUrl,
                 'minzoom': 0,
-                'maxzoom': 12
+                'maxzoom': 6
             }
         },
         'sprite': '',
@@ -266,7 +266,7 @@ export default {
                 'source': 'streams',
                 'source-layer': 'segsAllConus',
                 'minzoom': 0,
-                'maxzoom': 15,
+                'maxzoom': 6,
                 'layout': {
                     'visibility': 'visible'
                 },
@@ -307,7 +307,7 @@ export default {
                 'source': 'streams',
                 'source-layer': 'segsAllConus',
                 'minzoom': 0,
-                'maxzoom': 15,
+                'maxzoom': 6,
                 'layout': {
                     'visibility': 'none'
                 },


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
only allow zoom levels to 6

Description
-----------
https://github.com/usgs-makerspace/makerspace-sandbox/issues/603

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial