### PR TITLE
adjust so that map zoom level is slightly below tile max

### DIFF
--- a/src/views/waterTemperature/WaterTemperature.vue
+++ b/src/views/waterTemperature/WaterTemperature.vue
@@ -417,7 +417,7 @@
                 container: 'map',
                 zoom: 2,
                 minZoom: 2,
-                maxZoom: 6,
+                maxZoom: 5.99,
                 center: [-95.7129, 37.0902],
                 pitch: 0, // tips the map from 0 to 60 degrees
                 bearing: 0, // starting rotation of the map from 0 to 360


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
Keep entire map zoom just below max zoom of tile layer

Description
-----------
https://github.com/usgs-makerspace/makerspace-sandbox/issues/603

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial