### PR TITLE
Another attempt to having loading screen wait for map svg

### DIFF
--- a/src/components/LoadingScreenInternal.vue
+++ b/src/components/LoadingScreenInternal.vue
@@ -24,13 +24,8 @@ export default {
     fixed.addEventListener('touchmove', function(e){
       e.preventDefault();
     }, false);
-    if(this.isLoading === true){
-      document.body.classList.add("stop-scrolling");
-    }else{
-      document.body.classList.remove("stop-scrolling");
-    }
+    document.body.classList.remove("stop-scrolling");
   }
-  
 };
 </script>
 <style lang="scss">
@@ -88,7 +83,7 @@ export default {
 }
 
 .fadeout {
-  animation: fadeout 2s forwards;
+  animation: fadeout 1s forwards;
 }
 
 @keyframes fadeout {

--- a/src/views/waterUse/WaterUse.vue
+++ b/src/views/waterUse/WaterUse.vue
@@ -15,7 +15,7 @@
       id="water-use-content"
       class="waterUseFlex"
     >
-      <LoadingScreenInternal v-if="!isLoading" />
+      <LoadingScreenInternal :is-loading="isLoading" />
       <div
         id="buttonsContainer"
         class="centeredContent"
@@ -70,7 +70,7 @@
         titleSuffix: process.env.VUE_APP_TITLE_SUFFIX,
         featureName: 'Water Use',
         developmentTier: process.env.VUE_APP_TIER,
-        isLoading: this.$store.state.mapSVGRenderOnInitialLoad,
+        isLoading: true,
         isAboutMapInfoBoxOpen: true,
         isFirstClick: true,
         svg: "svg_map_te_spring",
@@ -115,6 +115,7 @@
           element.previousElementSibling.classList.add("activeSeason");
           this.changeWuBarFill();
         }
+        this.isLoading = false;
       },
       watchWuBarsHovers(){
         let self = this;


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
I can't seem to figure out how to explicitly wait for the Map SVG to render to make the loading screen go away, but heres another attempt.  Always works locally, but never on test.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial