### PR TITLE
SVGO transform control

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -15,7 +15,6 @@ module.exports = {
                         plugins: [
                             {removeDoctype: true},
                             {removeComments: true},
-                            {convertTransform: false},
                             {convertPathData: {
                                 removeUseless: false
                             }},


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
I previously had to disable the SVGO convertTransform control to have the barchart to display properly, but now that doesn't seem to be the case.  With it enable the SVG load has gone from 2.6MB to 25.4KB.  Pretty big difference.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial