### PR TITLE
Make irrigation winter visible

### DIFF
--- a/src/assets/wuBarSVGs/svg_bars_ir.svg
+++ b/src/assets/wuBarSVGs/svg_bars_ir.svg
@@ -32,11 +32,11 @@
   <g id="xAxis" transform="translate(0 267.5)">
     <path class="wu-bars-axis" d="M0,0 h1185"/>
     <path class="wu-bars-axis" d="M191.547945205479,0 v10 M490.232876712329,0 v10 M788.917808219178,0 v10 M1084.35616438356,0 v10"/>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(97.3972602739726 37.5)">Winter</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(342.513698630137 37.5)">Spring</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(641.198630136986 37.5)">Summer</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(938.260273972603 37.5)">Fall</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(1136.30136986301 37.5)">Winter</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(97.3972602739726 37)">Winter</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(342.513698630137 37)">Spring</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(641.198630136986 37)">Summer</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(938.260273972603 37)">Fall</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(1136.30136986301 37)">Winter</text>
     <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1133.05479452055 17)">Dec</text>
     <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1035.65753424658 17)">Nov</text>
     <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(935.013698630137 17)">Oct</text>

--- a/src/assets/wuBarSVGs/svg_bars_ir.svg
+++ b/src/assets/wuBarSVGs/svg_bars_ir.svg
@@ -29,25 +29,25 @@
       <tspan id="yUnits" x="0" dy="20">million gallons per day</tspan>
     </text>
   </g>
-  <g id="xAxis" transform="translate(0 265)">
+  <g id="xAxis" transform="translate(0 267.5)">
     <path class="wu-bars-axis" d="M0,0 h1185"/>
     <path class="wu-bars-axis" d="M191.547945205479,0 v10 M490.232876712329,0 v10 M788.917808219178,0 v10 M1084.35616438356,0 v10"/>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(97.3972602739726 35)">Winter</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(342.513698630137 35)">Spring</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(641.198630136986 35)">Summer</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(938.260273972603 35)">Fall</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(1136.30136986301 35)">Winter</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1133.05479452055 15)">Dec</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1035.65753424658 15)">Nov</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(935.013698630137 15)">Oct</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(837.616438356164 15)">Sep</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(736.972602739726 15)">Aug</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(636.328767123288 15)">Jul</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(538.931506849315 15)">Jun</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(438.287671232877 15)">May</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(340.890410958904 15)">Apr</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(240.246575342466 15)">Mar</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(149.342465753425 15)">Feb</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(48.6986301369863 15)">Jan</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(97.3972602739726 37.5)">Winter</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(342.513698630137 37.5)">Spring</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(641.198630136986 37.5)">Summer</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(938.260273972603 37.5)">Fall</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(1136.30136986301 37.5)">Winter</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1133.05479452055 17)">Dec</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1035.65753424658 17)">Nov</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(935.013698630137 17)">Oct</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(837.616438356164 17)">Sep</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(736.972602739726 17)">Aug</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(636.328767123288 17)">Jul</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(538.931506849315 17)">Jun</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(438.287671232877 17)">May</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(340.890410958904 17)">Apr</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(240.246575342466 17)">Mar</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(149.342465753425 17)">Feb</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(48.6986301369863 17)">Jan</text>
   </g>
 </svg>

--- a/src/assets/wuBarSVGs/svg_bars_ps.svg
+++ b/src/assets/wuBarSVGs/svg_bars_ps.svg
@@ -32,11 +32,11 @@
   <g id="xAxis" transform="translate(0 267.5)">
     <path class="wu-bars-axis" d="M0,0 h1185"/>
     <path class="wu-bars-axis" d="M191.547945205479,0 v10 M490.232876712329,0 v10 M788.917808219178,0 v10 M1084.35616438356,0 v10"/>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(97.3972602739726 37.5)">Winter</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(342.513698630137 37.5)">Spring</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(641.198630136986 37.5)">Summer</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(938.260273972603 37.5)">Fall</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(1136.30136986301 37.5)">Winter</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(97.3972602739726 37)">Winter</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(342.513698630137 37)">Spring</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(641.198630136986 37)">Summer</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(938.260273972603 37)">Fall</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(1136.30136986301 37)">Winter</text>
     <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1133.05479452055 17)">Dec</text>
     <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1035.65753424658 17)">Nov</text>
     <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(935.013698630137 17)">Oct</text>

--- a/src/assets/wuBarSVGs/svg_bars_ps.svg
+++ b/src/assets/wuBarSVGs/svg_bars_ps.svg
@@ -29,25 +29,25 @@
       <tspan id="yUnits" x="0" dy="20">million gallons per day</tspan>
     </text>
   </g>
-  <g id="xAxis" transform="translate(0 265)">
+  <g id="xAxis" transform="translate(0 267.5)">
     <path class="wu-bars-axis" d="M0,0 h1185"/>
     <path class="wu-bars-axis" d="M191.547945205479,0 v10 M490.232876712329,0 v10 M788.917808219178,0 v10 M1084.35616438356,0 v10"/>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(97.3972602739726 35)">Winter</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(342.513698630137 35)">Spring</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(641.198630136986 35)">Summer</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(938.260273972603 35)">Fall</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(1136.30136986301 35)">Winter</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1133.05479452055 15)">Dec</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1035.65753424658 15)">Nov</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(935.013698630137 15)">Oct</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(837.616438356164 15)">Sep</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(736.972602739726 15)">Aug</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(636.328767123288 15)">Jul</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(538.931506849315 15)">Jun</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(438.287671232877 15)">May</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(340.890410958904 15)">Apr</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(240.246575342466 15)">Mar</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(149.342465753425 15)">Feb</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(48.6986301369863 15)">Jan</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(97.3972602739726 37.5)">Winter</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(342.513698630137 37.5)">Spring</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(641.198630136986 37.5)">Summer</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(938.260273972603 37.5)">Fall</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(1136.30136986301 37.5)">Winter</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1133.05479452055 17)">Dec</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1035.65753424658 17)">Nov</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(935.013698630137 17)">Oct</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(837.616438356164 17)">Sep</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(736.972602739726 17)">Aug</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(636.328767123288 17)">Jul</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(538.931506849315 17)">Jun</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(438.287671232877 17)">May</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(340.890410958904 17)">Apr</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(240.246575342466 17)">Mar</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(149.342465753425 17)">Feb</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(48.6986301369863 17)">Jan</text>
   </g>
 </svg>

--- a/src/assets/wuBarSVGs/svg_bars_te.svg
+++ b/src/assets/wuBarSVGs/svg_bars_te.svg
@@ -32,11 +32,11 @@
   <g id="xAxis" transform="translate(0 267.5)">
     <path class="wu-bars-axis" d="M0,0 h1185"/>
     <path class="wu-bars-axis" d="M191.547945205479,0 v10 M490.232876712329,0 v10 M788.917808219178,0 v10 M1084.35616438356,0 v10"/>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(97.3972602739726 37.5)">Winter</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(342.513698630137 37.5)">Spring</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(641.198630136986 37.5)">Summer</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(938.260273972603 37.5)">Fall</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(1136.30136986301 37.5)">Winter</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(97.3972602739726 37)">Winter</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(342.513698630137 37)">Spring</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(641.198630136986 37)">Summer</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(938.260273972603 37)">Fall</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(1136.30136986301 37)">Winter</text>
     <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1133.05479452055 17)">Dec</text>
     <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1035.65753424658 17)">Nov</text>
     <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(935.013698630137 17)">Oct</text>

--- a/src/assets/wuBarSVGs/svg_bars_te.svg
+++ b/src/assets/wuBarSVGs/svg_bars_te.svg
@@ -29,25 +29,25 @@
       <tspan id="yUnits" x="0" dy="20">million gallons per day</tspan>
     </text>
   </g>
-  <g id="xAxis" transform="translate(0 265)">
+  <g id="xAxis" transform="translate(0 267.5)">
     <path class="wu-bars-axis" d="M0,0 h1185"/>
     <path class="wu-bars-axis" d="M191.547945205479,0 v10 M490.232876712329,0 v10 M788.917808219178,0 v10 M1084.35616438356,0 v10"/>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(97.3972602739726 35)">Winter</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(342.513698630137 35)">Spring</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(641.198630136986 35)">Summer</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(938.260273972603 35)">Fall</text>
-    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(1136.30136986301 35)">Winter</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1133.05479452055 15)">Dec</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1035.65753424658 15)">Nov</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(935.013698630137 15)">Oct</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(837.616438356164 15)">Sep</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(736.972602739726 15)">Aug</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(636.328767123288 15)">Jul</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(538.931506849315 15)">Jun</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(438.287671232877 15)">May</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(340.890410958904 15)">Apr</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(240.246575342466 15)">Mar</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(149.342465753425 15)">Feb</text>
-    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(48.6986301369863 15)">Jan</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(97.3972602739726 37.5)">Winter</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(342.513698630137 37.5)">Spring</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(641.198630136986 37.5)">Summer</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(938.260273972603 37.5)">Fall</text>
+    <text class="wu-bars-text seasonLabel" text-anchor="middle" transform="translate(1136.30136986301 37.5)">Winter</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1133.05479452055 17)">Dec</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(1035.65753424658 17)">Nov</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(935.013698630137 17)">Oct</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(837.616438356164 17)">Sep</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(736.972602739726 17)">Aug</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(636.328767123288 17)">Jul</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(538.931506849315 17)">Jun</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(438.287671232877 17)">May</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(340.890410958904 17)">Apr</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(240.246575342466 17)">Mar</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(149.342465753425 17)">Feb</text>
+    <text class="wu-bars-text monthLabel" text-anchor="middle" transform="translate(48.6986301369863 17)">Jan</text>
   </g>
 </svg>

--- a/wu_pipeline/6_visualize/src/build_svg_bars.R
+++ b/wu_pipeline/6_visualize/src/build_svg_bars.R
@@ -87,12 +87,14 @@ add_x_axis <- function(svg, wu_dat, svg_height, svg_width, season_info) {
   max_doy <- max(wu_dat$doy, na.rm=TRUE)
   scale_x_factor <- svg_width/max_doy # Needed to change x values rather than scaling which warps text
   
-  y_pos <- 35 # distance below x axis to put y label
+  y_pos <- 35 # distance below x axis to put label
   
   svg %>% 
     xml_add_child("g", id = "xAxis", 
                   transform = sprintf("translate(0 %s)", svg_height)) %>%  
+    # Line:
     xml_add_child("path", class = "wu-bars-axis", d = sprintf("M0,0 h%s", max_doy*scale_x_factor)) %>%
+    # Ticks:
     xml_add_sibling("path", class = "wu-bars-axis", 
                     d = paste(sprintf("M%s,0 v10", head(season_end_doy*scale_x_factor, -1)), collapse=" ")) %>% 
     add_season_label("Winter", x_pos = season_middle_doy[["winter1"]]*scale_x_factor, y_pos) %>% 

--- a/wu_pipeline/6_visualize/src/build_svg_bars.R
+++ b/wu_pipeline/6_visualize/src/build_svg_bars.R
@@ -87,12 +87,11 @@ add_x_axis <- function(svg, wu_dat, svg_height, svg_width, season_info, axis_str
   max_doy <- max(wu_dat$doy, na.rm=TRUE)
   scale_x_factor <- svg_width/max_doy # Needed to change x values rather than scaling which warps text
   
-  y_shift <- axis_stroke_width/2
-  y_pos <- 35 + y_shift # distance below x axis to put label
+  y_pos <- 37 # distance below x axis to put label
   
   svg %>% 
     xml_add_child("g", id = "xAxis", 
-                  transform = sprintf("translate(0 %s)", svg_height + y_shift)) %>%  
+                  transform = sprintf("translate(0 %s)", svg_height + axis_stroke_width/2)) %>%  
     # Line:
     xml_add_child("path", class = "wu-bars-axis", d = sprintf("M0,0 h%s", max_doy*scale_x_factor)) %>%
     # Ticks:

--- a/wu_pipeline/6_visualize/src/build_svg_bars.R
+++ b/wu_pipeline/6_visualize/src/build_svg_bars.R
@@ -79,7 +79,7 @@ add_y_axis <- function(svg, wu_dat, svg_height) {
   
 }
 
-add_x_axis <- function(svg, wu_dat, svg_height, svg_width, season_info) {
+add_x_axis <- function(svg, wu_dat, svg_height, svg_width, season_info, axis_stroke_width = 5) {
   
   season_start_doy <- unlist(lapply(season_info, get_startDate_as_doy))
   season_end_doy <- unlist(lapply(season_info, get_endDate_as_doy))
@@ -87,11 +87,12 @@ add_x_axis <- function(svg, wu_dat, svg_height, svg_width, season_info) {
   max_doy <- max(wu_dat$doy, na.rm=TRUE)
   scale_x_factor <- svg_width/max_doy # Needed to change x values rather than scaling which warps text
   
-  y_pos <- 35 # distance below x axis to put label
+  y_shift <- axis_stroke_width/2
+  y_pos <- 35 + y_shift # distance below x axis to put label
   
   svg %>% 
     xml_add_child("g", id = "xAxis", 
-                  transform = sprintf("translate(0 %s)", svg_height)) %>%  
+                  transform = sprintf("translate(0 %s)", svg_height + y_shift)) %>%  
     # Line:
     xml_add_child("path", class = "wu-bars-axis", d = sprintf("M0,0 h%s", max_doy*scale_x_factor)) %>%
     # Ticks:
@@ -102,7 +103,7 @@ add_x_axis <- function(svg, wu_dat, svg_height, svg_width, season_info) {
     add_season_label("Summer", x_pos = season_middle_doy[["summer"]]*scale_x_factor, y_pos) %>% 
     add_season_label("Fall", x_pos = season_middle_doy[["fall"]]*scale_x_factor, y_pos) %>% 
     add_season_label("Winter", x_pos = season_middle_doy[["winter2"]]*scale_x_factor, y_pos) %>% 
-    add_month_labels(y_pos = 15, scale_x_factor)
+    add_month_labels(y_pos = 17, scale_x_factor)
   
 }
 


### PR DESCRIPTION
We may need to do more beyond this, but my first thought was to move the x-axis down. It was overlapping the data due to having a stroke-width of 5, so I just needed to shift it down 2.5 so that the width brought it right up to the bottom of the data. You can now see the slivers of data. Once it is on test, we may want to talk about additional tricks to get those bottom slivers to be even more visible.

![image](https://user-images.githubusercontent.com/13220910/95247421-73fb1880-07db-11eb-858a-4ac488dd8637.png)

Part of https://github.com/usgs-makerspace/makerspace-sandbox/issues/652