### PR TITLE
re-order layers so that we block the river segments in canada

### DIFF
--- a/src/assets/mapStyles/waterTemperature/mapStyles.js
+++ b/src/assets/mapStyles/waterTemperature/mapStyles.js
@@ -29,7 +29,7 @@ export default {
             streams: {
                 type: 'vector',
                 'tiles': streamsTileUrl,
-                'minzoom': 0,
+                'minzoom': 2,
                 'maxzoom': 6
             }
         },
@@ -170,6 +170,61 @@ export default {
                 'showButtonLayerToggle': false
             },
             {
+                'id': 'Terrain',
+                'type': 'raster',
+                'source': 'hillshade',
+                'layout': {
+                    'visibility': 'none'
+                },
+                'showButtonLayerToggle': true
+            },
+            {
+                'id': 'Counties',
+                'type': 'line',
+                'source': 'basemap',
+                'source-layer': 'counties',
+                'minzoom': 4.5,
+                'maxzoom': 24,
+                'layout': {
+                    'visibility': 'none'
+                },
+                'paint': {
+                    'line-color': 'rgb(0,0,0)',
+                    'line-dasharray': [2, 4]
+                },
+                'showButtonLayerToggle': true
+            },
+
+            {
+                'id': 'streams_interpolated',
+                'layerDescription': 'all streams',
+                'type': 'line',
+                'source': 'streams',
+                'source-layer': 'segsAllConus',
+                'minzoom': 2,
+                'maxzoom': 6,
+                'layout': {
+                    'visibility': 'visible'
+                },
+                'filter': ["all", ["has", "temp"]],
+                'filter': ['==', ['typeof', ['get', 'temp']], 'number'],
+                "paint": {
+                    "line-width": [
+                        "interpolate", 
+                        ["linear"], ["zoom"],
+                        5, 1,
+                        6, 2
+                    ],
+                    "line-color": [
+                        "interpolate", ["linear"], ["get", "temp"],
+                        0, "#10305d", 
+                        14.08, "#c4c1b6",
+                        25.88, "#730000"
+                    ]
+                  }
+
+            },
+            {
                 'id': 'Neighboring Countries',
                 'type': 'fill',
                 'source': 'basemap',
@@ -218,31 +273,6 @@ export default {
                 'showButtonLayerToggle': false
             },
             {
-                'id': 'Terrain',
-                'type': 'raster',
-                'source': 'hillshade',
-                'layout': {
-                    'visibility': 'none'
-                },
-                'showButtonLayerToggle': true
-            },
-            {
-                'id': 'Counties',
-                'type': 'line',
-                'source': 'basemap',
-                'source-layer': 'counties',
-                'minzoom': 4.5,
-                'maxzoom': 24,
-                'layout': {
-                    'visibility': 'none'
-                },
-                'paint': {
-                    'line-color': 'rgb(0,0,0)',
-                    'line-dasharray': [2, 4]
-                },
-                'showButtonLayerToggle': true
-            },
-            {
                 'id': 'states',
                 'type': 'line',
                 'source': 'basemap',
@@ -255,35 +285,6 @@ export default {
                 'paint': {
                     'line-color': 'rgb(0,0,0)'
                 }
-
-            },
-            {
-                'id': 'streams_interpolated',
-                'layerDescription': 'all streams',
-                'type': 'line',
-                'source': 'streams',
-                'source-layer': 'segsAllConus',
-                'minzoom': 0,
-                'maxzoom': 6,
-                'layout': {
-                    'visibility': 'visible'
-                },
-                'filter': ["all", ["has", "temp"]],
-                'filter': ['==', ['typeof', ['get', 'temp']], 'number'],
-                "paint": {
-                    "line-width": [
-                        "interpolate", 
-                        ["linear"], ["zoom"],
-                        5, 1,
-                        6, 2
-                    ],
-                    "line-color": [
-                        "interpolate", ["linear"], ["get", "temp"],
-                        0, "#10305d", 
-                        14.08, "#c4c1b6",
-                        25.88, "#730000"
-                    ]
-                  }
 
             },
             {


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
hide canada's river segments

Description
-----------
re-ordering the different tile sets

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial