### PR TITLE
Update legend title

### DIFF
--- a/src/assets/wuMapSVGs/svg_map_ir_fall.svg
+++ b/src/assets/wuMapSVGs/svg_map_ir_fall.svg
@@ -180,6 +180,9 @@
     <text x="67" y="-5" class="legendValues">130</text>
     <circle cx="0" cy="10" r="1" class="smallDot"/>
     <text x="67" y="10" class="legendValues">&lt; 1</text>
-    <text x="15" y="-60" class="legendTitle">Water use, million gallons per day</text>
+    <text class="legendTitle">
+      <tspan x="15" y="-80">Seasonal-average daily water use</tspan>
+      <tspan x="15" y="-60" class="legendUnits">(million gallons per day)</tspan>
+    </text>
   </g>
 </svg>

--- a/src/assets/wuMapSVGs/svg_map_ir_spring.svg
+++ b/src/assets/wuMapSVGs/svg_map_ir_spring.svg
@@ -217,6 +217,9 @@
     <text x="67" y="-5" class="legendValues">130</text>
     <circle cx="0" cy="10" r="1" class="smallDot"/>
     <text x="67" y="10" class="legendValues">&lt; 1</text>
-    <text x="15" y="-60" class="legendTitle">Water use, million gallons per day</text>
+    <text class="legendTitle">
+      <tspan x="15" y="-80">Seasonal-average daily water use</tspan>
+      <tspan x="15" y="-60" class="legendUnits">(million gallons per day)</tspan>
+    </text>
   </g>
 </svg>

--- a/src/assets/wuMapSVGs/svg_map_ir_summer.svg
+++ b/src/assets/wuMapSVGs/svg_map_ir_summer.svg
@@ -311,6 +311,9 @@
     <text x="67" y="-5" class="legendValues">130</text>
     <circle cx="0" cy="10" r="1" class="smallDot"/>
     <text x="67" y="10" class="legendValues">&lt; 1</text>
-    <text x="15" y="-60" class="legendTitle">Water use, million gallons per day</text>
+    <text class="legendTitle">
+      <tspan x="15" y="-80">Seasonal-average daily water use</tspan>
+      <tspan x="15" y="-60" class="legendUnits">(million gallons per day)</tspan>
+    </text>
   </g>
 </svg>

--- a/src/assets/wuMapSVGs/svg_map_ir_winter.svg
+++ b/src/assets/wuMapSVGs/svg_map_ir_winter.svg
@@ -107,6 +107,9 @@
     <text x="67" y="-5" class="legendValues">130</text>
     <circle cx="0" cy="10" r="1" class="smallDot"/>
     <text x="67" y="10" class="legendValues">&lt; 1</text>
-    <text x="15" y="-60" class="legendTitle">Water use, million gallons per day</text>
+    <text class="legendTitle">
+      <tspan x="15" y="-80">Seasonal-average daily water use</tspan>
+      <tspan x="15" y="-60" class="legendUnits">(million gallons per day)</tspan>
+    </text>
   </g>
 </svg>

--- a/src/assets/wuMapSVGs/svg_map_ps_fall.svg
+++ b/src/assets/wuMapSVGs/svg_map_ps_fall.svg
@@ -272,6 +272,9 @@
     <text x="67" y="-5" class="legendValues">25</text>
     <circle cx="0" cy="10" r="1" class="smallDot"/>
     <text x="67" y="10" class="legendValues">&lt; 1</text>
-    <text x="15" y="-60" class="legendTitle">Water use, million gallons per day</text>
+    <text class="legendTitle">
+      <tspan x="15" y="-80">Seasonal-average daily water use</tspan>
+      <tspan x="15" y="-60" class="legendUnits">(million gallons per day)</tspan>
+    </text>
   </g>
 </svg>

--- a/src/assets/wuMapSVGs/svg_map_ps_spring.svg
+++ b/src/assets/wuMapSVGs/svg_map_ps_spring.svg
@@ -260,6 +260,9 @@
     <text x="67" y="-5" class="legendValues">25</text>
     <circle cx="0" cy="10" r="1" class="smallDot"/>
     <text x="67" y="10" class="legendValues">&lt; 1</text>
-    <text x="15" y="-60" class="legendTitle">Water use, million gallons per day</text>
+    <text class="legendTitle">
+      <tspan x="15" y="-80">Seasonal-average daily water use</tspan>
+      <tspan x="15" y="-60" class="legendUnits">(million gallons per day)</tspan>
+    </text>
   </g>
 </svg>

--- a/src/assets/wuMapSVGs/svg_map_ps_summer.svg
+++ b/src/assets/wuMapSVGs/svg_map_ps_summer.svg
@@ -282,6 +282,9 @@
     <text x="67" y="-5" class="legendValues">25</text>
     <circle cx="0" cy="10" r="1" class="smallDot"/>
     <text x="67" y="10" class="legendValues">&lt; 1</text>
-    <text x="15" y="-60" class="legendTitle">Water use, million gallons per day</text>
+    <text class="legendTitle">
+      <tspan x="15" y="-80">Seasonal-average daily water use</tspan>
+      <tspan x="15" y="-60" class="legendUnits">(million gallons per day)</tspan>
+    </text>
   </g>
 </svg>

--- a/src/assets/wuMapSVGs/svg_map_ps_winter.svg
+++ b/src/assets/wuMapSVGs/svg_map_ps_winter.svg
@@ -261,6 +261,9 @@
     <text x="67" y="-5" class="legendValues">25</text>
     <circle cx="0" cy="10" r="1" class="smallDot"/>
     <text x="67" y="10" class="legendValues">&lt; 1</text>
-    <text x="15" y="-60" class="legendTitle">Water use, million gallons per day</text>
+    <text class="legendTitle">
+      <tspan x="15" y="-80">Seasonal-average daily water use</tspan>
+      <tspan x="15" y="-60" class="legendUnits">(million gallons per day)</tspan>
+    </text>
   </g>
 </svg>

--- a/src/assets/wuMapSVGs/svg_map_te_fall.svg
+++ b/src/assets/wuMapSVGs/svg_map_te_fall.svg
@@ -241,6 +241,9 @@
     <text x="67" y="-5" class="legendValues">170</text>
     <circle cx="0" cy="10" r="1" class="smallDot"/>
     <text x="67" y="10" class="legendValues">&lt; 1</text>
-    <text x="15" y="-60" class="legendTitle">Water use, million gallons per day</text>
+    <text class="legendTitle">
+      <tspan x="15" y="-80">Seasonal-average daily water use</tspan>
+      <tspan x="15" y="-60" class="legendUnits">(million gallons per day)</tspan>
+    </text>
   </g>
 </svg>

--- a/src/assets/wuMapSVGs/svg_map_te_spring.svg
+++ b/src/assets/wuMapSVGs/svg_map_te_spring.svg
@@ -243,6 +243,9 @@
     <text x="67" y="-5" class="legendValues">170</text>
     <circle cx="0" cy="10" r="1" class="smallDot"/>
     <text x="67" y="10" class="legendValues">&lt; 1</text>
-    <text x="15" y="-60" class="legendTitle">Water use, million gallons per day</text>
+    <text class="legendTitle">
+      <tspan x="15" y="-80">Seasonal-average daily water use</tspan>
+      <tspan x="15" y="-60" class="legendUnits">(million gallons per day)</tspan>
+    </text>
   </g>
 </svg>

--- a/src/assets/wuMapSVGs/svg_map_te_summer.svg
+++ b/src/assets/wuMapSVGs/svg_map_te_summer.svg
@@ -260,6 +260,9 @@
     <text x="67" y="-5" class="legendValues">170</text>
     <circle cx="0" cy="10" r="1" class="smallDot"/>
     <text x="67" y="10" class="legendValues">&lt; 1</text>
-    <text x="15" y="-60" class="legendTitle">Water use, million gallons per day</text>
+    <text class="legendTitle">
+      <tspan x="15" y="-80">Seasonal-average daily water use</tspan>
+      <tspan x="15" y="-60" class="legendUnits">(million gallons per day)</tspan>
+    </text>
   </g>
 </svg>

--- a/src/assets/wuMapSVGs/svg_map_te_winter.svg
+++ b/src/assets/wuMapSVGs/svg_map_te_winter.svg
@@ -245,6 +245,9 @@
     <text x="67" y="-5" class="legendValues">170</text>
     <circle cx="0" cy="10" r="1" class="smallDot"/>
     <text x="67" y="10" class="legendValues">&lt; 1</text>
-    <text x="15" y="-60" class="legendTitle">Water use, million gallons per day</text>
+    <text class="legendTitle">
+      <tspan x="15" y="-80">Seasonal-average daily water use</tspan>
+      <tspan x="15" y="-60" class="legendUnits">(million gallons per day)</tspan>
+    </text>
   </g>
 </svg>

--- a/wu_pipeline/6_visualize/src/build_svg_map.R
+++ b/wu_pipeline/6_visualize/src/build_svg_map.R
@@ -93,8 +93,11 @@ add_legend <- function(svg, legend_size_dat, svg_width, svg_height, wu_type_cd) 
   
   # Add text above circles
   wu_legend %>% 
-    xml_add_child('text', x = label_line_length/2, y = -max(legend_size_dat$radius)*2*1.50, 
-                  "Water use, million gallons per day", class = "legendTitle")
+    xml_add_child('text', class = "legendTitle") %>% 
+    xml_add_child('tspan', x = label_line_length/2, y = -max(legend_size_dat$radius)*2*2.0, 
+                  "Seasonal-average daily water use") %>% 
+    xml_add_sibling('tspan', x = label_line_length/2, y = -max(legend_size_dat$radius)*2*1.50, 
+                    "(million gallons per day)", class = "legendUnits")
 }
 
 add_circle_with_label <- function(svg, r, label, label_line_length, extra_label_nudge = 0) {


### PR DESCRIPTION
Updates legend title (via https://github.com/usgs-makerspace/makerspace-sandbox/issues/668) and moves units onto second line. Added extra class to `tspan` that contains the units only so that they can be styled differently (smaller, italicized, etc) if @mwernimont thinks they should be.