### PR TITLE
move water use refs above water temp references

### DIFF
--- a/src/components/References.vue
+++ b/src/components/References.vue
@@ -18,9 +18,9 @@
         </a>
       </p>
     </div>
-    <h2>{{ titleWaterTemp }}</h2>
+    <h2>{{ titleWaterUse }}</h2>
     <div
-      v-for="reference in referencesWaterTemp"
+      v-for="reference in referencesWaterUse"
       :key="reference.reference"
     >
       <p class="about-ref">
@@ -33,9 +33,9 @@
         </a>
       </p>
     </div>
-    <h2>{{ titleWaterUse }}</h2>
+    <h2>{{ titleWaterTemp }}</h2>
     <div
-      v-for="reference in referencesWaterUse"
+      v-for="reference in referencesWaterTemp"
       :key="reference.reference"
     >
       <p class="about-ref">
@@ -60,10 +60,10 @@
           return {
               titleWaterStorage: references.referenceSectionWaterStorage.title,
               referencesWaterStorage: references.referenceSectionWaterStorage.references,
-              titleWaterTemp: references.referenceSectionWaterTemp.title,
-              referencesWaterTemp: references.referenceSectionWaterTemp.references,
               titleWaterUse: references.referenceSectionWaterUse.title,
-              referencesWaterUse: references.referenceSectionWaterUse.references
+              referencesWaterUse: references.referenceSectionWaterUse.references,
+              titleWaterTemp: references.referenceSectionWaterTemp.title,
+              referencesWaterTemp: references.referenceSectionWaterTemp.references
           };
       },
   }


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
https://github.com/usgs-makerspace/makerspace-sandbox/issues/689

Description
-----------
move references around to match the order of water storage, water use, water temperature

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial