### PR TITLE
WBEEP #674: water use: make the map bigger on desktop/laptop view

### DIFF
--- a/src/views/waterUse/WaterUse.vue
+++ b/src/views/waterUse/WaterUse.vue
@@ -22,70 +22,34 @@
         </div>
       </router-link>
     </div>
-    <div
-      id="water-use-content"
-      class="waterUseFlex"
-    >
+    <div class="water-use-content">
       <LoadingScreenInternal :is-loading="isLoading" />
-      <div
-        id="buttonsContainer"
-        class="centeredContent"
-      >
-        <div
-          id="buttonExplanation"
-          class="explanation"
-        >
-          <div class="instructionNumber">
-            1
-          </div>
+      <div id="buttonsContainer" class="centeredContent">
+        <div id="buttonExplanation" class="explanation">
+          <div class="instructionNumber">1</div>
           <p>First, select water use type (spring default view)</p>
         </div>
-        <button
-          id="te"
-          class="waterUseButton activeParameter"
-          @click="useButtonClick($event)"
-        >
+        <button id="te" class="waterUseButton activeParameter" @click="useButtonClick($event)">
           Thermoelectric
         </button>
-        <button
-          id="ir"
-          class="waterUseButton"
-          @click="useButtonClick($event)"
-        >
+        <button id="ir" class="waterUseButton" @click="useButtonClick($event)">
           Irrigation
         </button>
-        <button
-          id="ps"
-          class="waterUseButton"
-          @click="useButtonClick($event)"
-        >
+        <button id="ps" class="waterUseButton" @click="useButtonClick($event)">
           Public Supply
         </button>
       </div>
-      <div
-        id="waterUseMapContainer"
-      >
-        <DynamicSVG
-          id="dynamicSVG"
-          :svg="svg"
-        />
-      </div>
-      <div
-        id="waterUseBarChartContainer"
-      >
-        <div
-          id="chartExplanation"
-          class="explanation"
-        >
-          <div class="instructionNumber">
-            2
-          </div>
+    </div>
+    <div id="waterUseMapContainer">
+      <DynamicSVG id="dynamicSVG" :svg="svg" />
+    </div>
+    <div class="water-use-content">
+      <div id="waterUseBarChartContainer">
+        <div id="chartExplanation" class="explanation">
+          <div class="instructionNumber">2</div>
           <p>Next, select season</p> 
         </div>
-        <DynamicBarChart
-          :barchart="barchart"
-          @click.native="changeSeason($event)"
-        />
+        <DynamicBarChart :barchart="barchart" @click.native="changeSeason($event)" />
       </div>
     </div>
   </div>
@@ -348,12 +312,10 @@ $barChartHighlight: red;
     color: #000;
   }
 }
-#water-use-content{
+.water-use-content{
   width: 100%;
   padding: 0 10px;
   max-width: 800px;
-  flex: 1;
-  display: flex;
 }
 #mapSubtitleContainer{
   position: relative;
@@ -441,6 +403,8 @@ $barChartHighlight: red;
   }
 }
 #waterUseMapContainer{
+  width: 100%;
+  max-width: 1500px;
   margin: 20px 0;
   position: relative;
   /*colors the SVG map*/
@@ -535,17 +499,17 @@ path.wu-bars-axis {
   }
 }
 @media screen and (min-width: 1100px) and (min-height: 1400px){
-  #water-use-content{
+  .water-use-content{
     max-width: 1100px;
   }
 }
 @media screen and (min-width: 1300px) and (max-height: 768px){
-  #water-use-content{
+  .water-use-content{
     width: 650px;
   }
 }
 @media screen and (min-width: 1000px) and (max-height: 652px){
-  #water-use-content{
+  .water-use-content{
     width: 530px;
   }
 }


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
Separated the map from the other contents constraints and gave it an arbitrary 1500px max-width.  Feel free to play with the max-width CSS declaration in the Water Use CSS on #waterUseMapContainer and see if you like another max-size for your screen.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial