### PR TITLE
use artifactory mirror to get around docker hub limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM artifactory.wma.chs.usgs.gov/docker-official-mirror/debian:stretch
 
 LABEL maintainer="makerspace-team@usgs.gov"
 


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
workaround for docker hub rate limit failure

Description
-----------
per an email from ivan, we should try to have our own artifactory mirror the package if we can. we just bumped into this a little while ago building the wbeep-viz ui on jenkins, hopefully this fixes.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial