### PR TITLE
Layer adjustments related to inland waters

### DIFF
--- a/src/assets/mapStyles/waterTemperature/mapStyles.js
+++ b/src/assets/mapStyles/waterTemperature/mapStyles.js
@@ -31,6 +31,12 @@ export default {
                 'tiles': streamsTileUrl,
                 'minzoom': 2,
                 'maxzoom': 6
+            },
+            greatlakes: {
+                type: 'vector',
+                'tiles': ['https://maptiles-prod-website.s3-us-west-2.amazonaws.com/greatlakes/{z}/{x}/{y}.pbf'],
+                'minzoom': 2,
+                'maxzoom': 6
             }
         },
         'sprite': '',
@@ -39,110 +45,27 @@ export default {
             {
                 'id': 'background',
                 'paint': {
-                    'background-color': 'hsl(47, 26%, 88%)'
+                    'background-color': 'hsl(205, 56%, 73%)'
                 },
                 'type': 'background',
                 'showButtonLayerToggle': false
             },
-            {
+/*             {
                 'filter': ['all', ['==', '$type', 'Polygon'],
-                    ['==', 'intermittent', 1]
+                    ['!=', 'intermittent', 1]
                 ],
-                'id': 'water_intermittent',
+                'id': 'water',
                 'paint': {
-                    'fill-color': '#DBF3FA',
-                    'fill-opacity': 0.7
+                    'fill-color': 'hsl(205, 56%, 73%)'
                 },
                 'source': 'openmaptiles',
                 'source-layer': 'water',
                 'type': 'fill',
                 'layout': {
-                    'visibility': 'none'
-                },
-                'showButtonLayerToggle': false
-            },
-            {
-                'filter': ['all', ['==', '$type', 'LineString'],
-                    ['==', 'brunnel', 'tunnel']
-                ],
-                'id': 'waterway-tunnel',
-                'paint': {
-                    'line-color': '#DBF3FA',
-                    'line-dasharray': [3, 3],
-                    'line-gap-width': {
-                        'stops': [
-                            [12, 0],
-                            [20, 6]
-                        ]
-                    },
-                    'line-opacity': 1,
-                    'line-width': {
-                        'base': 1.4,
-                        'stops': [
-                            [8, 1],
-                            [20, 2]
-                        ]
-                    }
-                },
-                'source': 'openmaptiles',
-                'source-layer': 'waterway',
-                'type': 'line',
-                'layout': {
                     'visibility': 'visible'
                 },
                 'showButtonLayerToggle': false
-            },
-            {
-                'filter': ['all', ['==', '$type', 'LineString'],
-                    ['!in', 'brunnel', 'tunnel', 'bridge'],
-                    ['!=', 'intermittent', 1]
-                ],
-                'id': 'waterway',
-                'paint': {
-                    'line-color': '#DBF3FA',
-                    'line-opacity': 1,
-                    'line-width': {
-                        'base': 1.4,
-                        'stops': [
-                            [8, 1],
-                            [20, 8]
-                        ]
-                    }
-                },
-                'source': 'openmaptiles',
-                'source-layer': 'waterway',
-                'type': 'line',
-                'layout': {
-                    'visibility': 'visible'
-                },
-                'showButtonLayerToggle': false
-            },
-            {
-                'filter': ['all', ['==', '$type', 'LineString'],
-                    ['!in', 'brunnel', 'tunnel', 'bridge'],
-                    ['==', 'intermittent', 1]
-                ],
-                'id': 'waterway_intermittent',
-                'paint': {
-                    'line-color': '#DBF3FA',
-                    'line-opacity': 1,
-                    'line-width': {
-                        'base': 1.4,
-                        'stops': [
-                            [8, 1],
-                            [20, 8]
-                        ]
-                    },
-                    'line-dasharray': [2, 1]
-                },
-                'source': 'openmaptiles',
-                'source-layer': 'waterway',
-                'type': 'line',
-                'layout': {
-                    'visibility': 'none'
-                },
-                'showButtonLayerToggle': false
-            },
+            }, */
             {
                 'id': 'Counties',
                 'type': 'line',
@@ -159,7 +82,21 @@ export default {
                 },
                 'showButtonLayerToggle': true
             },
+            {
+                'id': 'states-fill',
+                'type': 'fill',
+                'source': 'basemap',
+                'source-layer': 'states',
+                'minzoom': 2,
+                'maxzoom': 24,
+                'layout': {
+                    'visibility': 'visible',
+                },
+                'paint': {
+                    'fill-color': 'hsl(47, 26%, 88%)'
+                }
 
+            },
             {
                 'id': 'streams_interpolated',
                 'layerDescription': 'all streams',
@@ -183,8 +120,8 @@ export default {
                     "line-color": [
                         "interpolate", ["linear"], ["get", "temp"],
                         0, "#10305d", 
-                        14.08, "#c4c1b6",
-                        25.88, "#730000"
+                        15, "#c4c1b6",
+                        30, "#730000"
                     ]
                   }
 
@@ -205,46 +142,18 @@ export default {
                 'showButtonLayerToggle': false
             },
             {
-                'id': 'Terrain',
-                'type': 'raster',
-                'source': 'hillshade',
-                'layout': {
-                    'visibility': 'none'
-                },
-                'showButtonLayerToggle': true
-            },
-            {
-                'filter': ['all', ['==', '$type', 'Polygon'],
-                    ['!=', 'intermittent', 1]
-                ],
-                'id': 'water',
-                'paint': {
-                    'fill-color': '#CFEEFA',
-                    'fill-opacity': 0.3
-                },
-                'source': 'openmaptiles',
-                'source-layer': 'water',
+                'id': 'Great Lakes',
                 'type': 'fill',
-                'layout': {
+                'source': 'greatlakes',
+                'minzoom' : 0,
+                'maxzoom': 6,
+                'source-layer': 'Great_Lakes',
+                'layout' : {
                     'visibility': 'visible'
                 },
-                'showButtonLayerToggle': false
-            },
-            {
-                'filter': ['all', ['==', '$type', 'Polygon'],
-                    ['!=', 'intermittent', 1]
-                ],
-                'id': 'water-outline',
                 'paint': {
-                    'line-color': "#CFEEFA"
-                },
-                'source': 'openmaptiles',
-                'source-layer': 'water',
-                'type': 'line',
-                'layout': {
-                    'visibility': 'visible'
-                },
-                'showButtonLayerToggle': false
+                    'fill-color': 'hsl(205, 56%, 73%)'
+                }
             },
             {
                 'id': 'states',
@@ -260,6 +169,15 @@ export default {
                     'line-color': 'rgb(0,0,0)'
                 }
 
+            },
+            {
+                'id': 'Terrain',
+                'type': 'raster',
+                'source': 'hillshade',
+                'layout': {
+                    'visibility': 'none'
+                },
+                'showButtonLayerToggle': true
             },
             {
                 'filter': ['all', ['==', '$type', 'Point'],

--- a/src/assets/mapStyles/waterTemperature/mapStyles.js
+++ b/src/assets/mapStyles/waterTemperature/mapStyles.js
@@ -50,22 +50,6 @@ export default {
                 'type': 'background',
                 'showButtonLayerToggle': false
             },
-/*             {
-                'filter': ['all', ['==', '$type', 'Polygon'],
-                    ['!=', 'intermittent', 1]
-                ],
-                'id': 'water',
-                'paint': {
-                    'fill-color': 'hsl(205, 56%, 73%)'
-                },
-                'source': 'openmaptiles',
-                'source-layer': 'water',
-                'type': 'fill',
-                'layout': {
-                    'visibility': 'visible'
-                },
-                'showButtonLayerToggle': false
-            }, */
             {
                 'id': 'Counties',
                 'type': 'line',


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
https://github.com/usgs-makerspace/makerspace-sandbox/issues/680

Description
-----------
- removed the baselayer water features because we wanted to eliminate inland water bodies that are making it hard to interpret the stream temp colors
- created a new tile set for only the great lakes and added to a jenkins job that puts the tiles in our s3 maptiles prod bucket (pr to come for wbeep-processing jenkinsfile behind that)
- re-ordered the layers to get arrangement correct
- adjusted the oceans and great lakes water color to be the more 'bold' blue color from water storage that people liked in the feedback from review, we can do this now that we aren't showing the inland waters.
- added a state fill layer to fill the states in after changing background layer to be the water color

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial