### PR TITLE
move counties on top of the state fill layer

### DIFF
--- a/src/assets/mapStyles/waterTemperature/mapStyles.js
+++ b/src/assets/mapStyles/waterTemperature/mapStyles.js
@@ -51,6 +51,21 @@ export default {
                 'showButtonLayerToggle': false
             },
             {
+                'id': 'states-fill',
+                'type': 'fill',
+                'source': 'basemap',
+                'source-layer': 'states',
+                'minzoom': 2,
+                'maxzoom': 24,
+                'layout': {
+                    'visibility': 'visible',
+                },
+                'paint': {
+                    'fill-color': 'hsl(47, 26%, 88%)'
+                }
+
+            },
+            {
                 'id': 'Counties',
                 'type': 'line',
                 'source': 'basemap',
@@ -65,21 +80,6 @@ export default {
                     'line-dasharray': [2, 4]
                 },
                 'showButtonLayerToggle': true
-            },
-            {
-                'id': 'states-fill',
-                'type': 'fill',
-                'source': 'basemap',
-                'source-layer': 'states',
-                'minzoom': 2,
-                'maxzoom': 24,
-                'layout': {
-                    'visibility': 'visible',
-                },
-                'paint': {
-                    'fill-color': 'hsl(47, 26%, 88%)'
-                }
-
             },
             {
                 'id': 'streams_interpolated',


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
move counties on top of the state fill layer

Description
-----------
goofed up layer order for counties, needs to be on top of state fill.


After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial