### PR TITLE
Layers Road Bug Fix

### DIFF
--- a/src/views/waterStorage/WaterStorage.vue
+++ b/src/views/waterStorage/WaterStorage.vue
@@ -180,10 +180,10 @@
                   const targetElement = document.getElementById(`${buttonId}-button`);
 
                   if (layerToChange[0].minzoom > self.currentZoom) {
-                      targetElement.className = 'unavailable';
+                      targetElement.classList.add('unavailable');
                       targetElement.disabled = true;
-                  } else if (targetElement.className === 'unavailable') {
-                      targetElement.className = '';
+                  } else if (targetElement.classList.contains('unavailable')){
+                      targetElement.classList.remove('unavailable');
                       targetElement.disabled = false;
                   }
               });
@@ -207,6 +207,7 @@
                   idsOfButtonsOffWhenPageFirstLoads.includes(elementId) ? mapLayerButton.className = '' : mapLayerButton.className = 'active';
                   mapLayerButton.textContent = elementId; // Set the wording (label) for the layer toggle button to match the 'elementId' listed in the style sheet
                   mapLayerButton.onclick = function(e) {  // Creates a click event for each button so that when clicked by the user, the visibility property is changed as is the class (color) of the button
+                      console.log(elementId);
                       googleAnalytics('layers-menu', 'click', 'user clicked ' + elementId);
                       let clickedLayer = this.textContent;
                       let clickedLayerParent = this.parentElement;

--- a/src/views/waterStorage/WaterStorage.vue
+++ b/src/views/waterStorage/WaterStorage.vue
@@ -207,7 +207,6 @@
                   idsOfButtonsOffWhenPageFirstLoads.includes(elementId) ? mapLayerButton.className = '' : mapLayerButton.className = 'active';
                   mapLayerButton.textContent = elementId; // Set the wording (label) for the layer toggle button to match the 'elementId' listed in the style sheet
                   mapLayerButton.onclick = function(e) {  // Creates a click event for each button so that when clicked by the user, the visibility property is changed as is the class (color) of the button
-                      console.log(elementId);
                       googleAnalytics('layers-menu', 'click', 'user clicked ' + elementId);
                       let clickedLayer = this.textContent;
                       let clickedLayerParent = this.parentElement;


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
So I got it to highlight blue correctly, but VPN is not letting me log on to see if the roads layers loads correctly too, but I am guessing it would?

Anyways, the issue seems to have been how we wanted this layer active AND unavailable at the beginning height.  The function that got rid of the unavailable class was doing a hard class clear, so active was wiped as well.  So, I switched it to classList functionality, that way we can specifically change the unavailable class over doing hard wipes.  Let me know what you think.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial