### PR TITLE
uswds from 2.7.1 to 2.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "d3": "^5.16.0",
     "dns": "^0.2.2",
     "mapbox-gl": "^1.11.1",
-    "uswds": "^2.7.1",
+    "uswds": "^2.12.0",
     "vue": "^2.6.11",
     "vue-analytics": "^5.22.1",
     "vue-browser-detect-plugin": "^0.1.13",


### PR DESCRIPTION
The dependabot version had a conflict I wasn't sure how to resolve, and since the dependabot service changed so it will no longer resolve its own conflicts, just re-did the PR here

Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
If no ticket is referenced, describe the changes made. Note anything that you want the reviewers to know while
reviewing your pull request

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial